### PR TITLE
added slimbook to the available hardware

### DIFF
--- a/general/available_hardware.md
+++ b/general/available_hardware.md
@@ -24,6 +24,15 @@
 - 256 GB, PCIe-NVMe OPAL2.0: 
 - Intel HD Graphics 520
 
+## Slimbook katana 13"
+- Intel i7-6500U
+- 16GB DDR3L
+- SSD mSata 250GB
+- LED Antiglare 13.3" FullHD 1920x1080 
+- Intel HD Graphics 520
+- WiFi, Intel Dual Band 7265AC
+- keyboard spanish+english
+- [link](https://slimbook.es/en/ultrabook-katana-en)
 
 # Keyboards 
 - [Rantopad MXX](https://www.amazon.es/Rantopad-MXX-Mechanical-Gaming-Keyboard/dp/B01JIPTFL2/ref=sr_1_cc_1?s=aps&ie=UTF8&qid=1483029977&sr=1-1-catcorr&keywords=rantopad&th=1)


### PR DESCRIPTION
I'd like to propose a new laptop to be included in the available hardware list.

Slimbook is a Spanish brand who assembles laptops only with Linux-compatible hardware. I have had one as my personal laptop for the last one and a half year and it's a really good device.

The main point to consider is the quality/price relation, the configuration I attach in the PR (i7, 16GB RAM, 256 SSD) has a price under 1200€ (1174,00 €), while the other options are over 2000€, and 2 warranty years is included.