### PR TITLE
remove <br> tags from Markdown file

### DIFF
--- a/general/culture.md
+++ b/general/culture.md
@@ -8,7 +8,8 @@ For this reason we decided to aim for a unique company culture that many people 
 
 It's built around three pillars:
 
-### For Developers:
+### For Developers
+
 We want to always remain a company that does everything with the individual developer in mind. Not the developer as an employee of a company, but the developer as an individual in the developer community.
 
 For this reason we always put the developers’ interest first, not those of our clients, neither those of source{d}.
@@ -22,6 +23,7 @@ This is also the reason why we open source our work and why we will never charge
 A lot of people would rather build an organization purely focused on making money, but that’s not our goal. We want to empower developers, building a profitable and sustainable business is a consequence of this.
 
 ### By Developers
+
 In order to always do what is best for developers we need to put ourselves in their situation, but that is very hard to do if you’ve never been a developer yourself.
 
 For this reason we only hire computer scientists, developers or people who have a strong developer mindset and are willing to become one. This applies to all positions, from Sales to Talent.
@@ -31,6 +33,7 @@ Those who are not computer scientists or developers need to learn about computer
 Many people we interview don’t want to work at a company where everyone is either a CS, a developer or is becoming one. That’s great, it’s what makes our culture unique and what makes those who join us love being here.
 
 ### Opinionatedly Free Spoken
+
 We’re huge believers in free speech. You can learn something from every single person in the world, no matter what their opinion on any topic is. We also believe that this is a big part of open source, being able to learn and collaborate with people from all over the world who have a wide variety of different opinions on how to do things.
 
 No matter if you’re a socialist, totalitarian, libertarian, conservative or don’t want to be defined, we don’t believe in silencing those who don’t think like the general consensus since we believe that’s a lost opportunity to learn. As long as people remain respectful to those who think differently, no matter how differently. You can criticize ideas, but you can’t criticize people. Political views is just one example, on a day to day basis we see this in discussions about technologies, solutions to problems, and allowing people to openly voice without judgement and with respect who they are and what they stand for. For this reason we only hire people who are authentic and we give them the opportunity and encouragement to give their opinion, no matter what it is.

--- a/general/culture.md
+++ b/general/culture.md
@@ -1,41 +1,42 @@
 # Culture
-At source{d} we don't believe that being transparent, diverse, honest, etc can be called company culture. For us that's just general consensus of what a good company is like.<br>
-We believe that for a company culture to be effective and attract the right people it needs to be unique and it needs to create as many detractors as lovers. Those who dislike your company culture should join a different company, that’s perfectly fine. But those who love it will stay through the hardest of times and truly know that this company is their own and that it stands for the things they believe in.<br>
-For this reason we decided to aim for a unique company culture that many people will dislike, but one that we deeply believe in.<br>
-<br>
+
+At source{d} we don't believe that being transparent, diverse, honest, etc can be called company culture. For us that's just general consensus of what a good company is like.
+
+We believe that for a company culture to be effective and attract the right people it needs to be unique and it needs to create as many detractors as lovers. Those who dislike your company culture should join a different company, that’s perfectly fine. But those who love it will stay through the hardest of times and truly know that this company is their own and that it stands for the things they believe in.
+
+For this reason we decided to aim for a unique company culture that many people will dislike, but one that we deeply believe in.
+
 It's built around three pillars:
 
 ### For Developers:
-We want to always remain a company that does everything with the individual developer in mind. Not the developer as an employee of a company, but the developer as an individual in the developer community.<br>
-<br>
-For this reason we always put the developers’ interest first, not those of our clients, neither those of source{d}.<br>
-<br>
-This is easier said than done. When we decided to stop the cold email outreach to developers we knowingly lost a lot of revenue, but it was the right thing to do.<br>
-<br>
-Now every time we have to make a decision or start to work on something we ask ourselves if what we’re doing is the best thing we could possibly do for developers. The answer needs to be a clear “Yes!”.<br>
-<br>
-This is also the reason why we open source our work and why we will never charge individual developers or open source projects for the usage of our products.<br>
-<br>
-A lot of people would rather build an organization purely focused on making money, but that’s not our goal. We want to empower developers, building a profitable and sustainable business is a consequence of this.<br>
-<br>
+We want to always remain a company that does everything with the individual developer in mind. Not the developer as an employee of a company, but the developer as an individual in the developer community.
+
+For this reason we always put the developers’ interest first, not those of our clients, neither those of source{d}.
+
+This is easier said than done. When we decided to stop the cold email outreach to developers we knowingly lost a lot of revenue, but it was the right thing to do.
+
+Now every time we have to make a decision or start to work on something we ask ourselves if what we’re doing is the best thing we could possibly do for developers. The answer needs to be a clear “Yes!”.
+
+This is also the reason why we open source our work and why we will never charge individual developers or open source projects for the usage of our products.
+
+A lot of people would rather build an organization purely focused on making money, but that’s not our goal. We want to empower developers, building a profitable and sustainable business is a consequence of this.
 
 ### By Developers
-In order to always do what is best for developers we need to put ourselves in their situation, but that is very hard to do if you’ve never been a developer yourself.<br>
-<br>
-For this reason we only hire computer scientists, developers or people who have a strong developer mindset and are willing to become one. This applies to all positions, from Sales to Talent.<br>
-<br>
-Those who are not computer scientists or developers need to learn about computer science as well as coding. This is a compulsory condition. We have now open sourced our “Developer Training” for everyone to be able to suggest improvements or to use it at their own companies (it’s a work in progress and we hope to get your feedback in the form of issues and pull requests).<br>
-<br>
-Many people we interview don’t want to work at a company where everyone is either a CS, a developer or is becoming one. That’s great, it’s what makes our culture unique and what makes those who join us love being here.<br>
-<br>
+In order to always do what is best for developers we need to put ourselves in their situation, but that is very hard to do if you’ve never been a developer yourself.
+
+For this reason we only hire computer scientists, developers or people who have a strong developer mindset and are willing to become one. This applies to all positions, from Sales to Talent.
+
+Those who are not computer scientists or developers need to learn about computer science as well as coding. This is a compulsory condition. We have now open sourced our “Developer Training” for everyone to be able to suggest improvements or to use it at their own companies (it’s a work in progress and we hope to get your feedback in the form of issues and pull requests).
+
+Many people we interview don’t want to work at a company where everyone is either a CS, a developer or is becoming one. That’s great, it’s what makes our culture unique and what makes those who join us love being here.
 
 ### Opinionatedly Free Spoken
-We’re huge believers in free speech. You can learn something from every single person in the world, no matter what their opinion on any topic is. We also believe that this is a big part of open source, being able to learn and collaborate with people from all over the world who have a wide variety of different opinions on how to do things.<br>
-<br>
-No matter if you’re a socialist, totalitarian, libertarian, conservative or don’t want to be defined, we don’t believe in silencing those who don’t think like the general consensus since we believe that’s a lost opportunity to learn. As long as people remain respectful to those who think differently, no matter how differently. You can criticize ideas, but you can’t criticize people. Political views is just one example, on a day to day basis we see this in discussions about technologies, solutions to problems, and allowing people to openly voice without judgement and with respect who they are and what they stand for. For this reason we only hire people who are authentic and we give them the opportunity and encouragement to give their opinion, no matter what it is.<br>
-<br>
-Everybody has the right to have an opinion (that doesn’t harm or disrespects someone else), and that is something that reflects how the company works. By people feeling free to say whatever they think without being judged, they also feel free to contribute crazy ideas to the company, which creates a very dynamic environment.<br>
-<br>
+We’re huge believers in free speech. You can learn something from every single person in the world, no matter what their opinion on any topic is. We also believe that this is a big part of open source, being able to learn and collaborate with people from all over the world who have a wide variety of different opinions on how to do things.
+
+No matter if you’re a socialist, totalitarian, libertarian, conservative or don’t want to be defined, we don’t believe in silencing those who don’t think like the general consensus since we believe that’s a lost opportunity to learn. As long as people remain respectful to those who think differently, no matter how differently. You can criticize ideas, but you can’t criticize people. Political views is just one example, on a day to day basis we see this in discussions about technologies, solutions to problems, and allowing people to openly voice without judgement and with respect who they are and what they stand for. For this reason we only hire people who are authentic and we give them the opportunity and encouragement to give their opinion, no matter what it is.
+
+Everybody has the right to have an opinion (that doesn’t harm or disrespects someone else), and that is something that reflects how the company works. By people feeling free to say whatever they think without being judged, they also feel free to contribute crazy ideas to the company, which creates a very dynamic environment.
+
 Not everyone will like our culture, but that’s the point of it ;)
 
 # 


### PR DESCRIPTION
The first three paragraphs of `general/culture.md` were not correctly rendered in markdown as they had no paragraph separators.  Then I realize the whole file didn't use paragraph separators at all; instead it was using HTML `<br>` tags for some reason (bad format conversion from an editor maybe?).

This patch fixes the rendering of the first three paragraphs and turns the file into a correctly formatted markdown file by adding paragraph separators.

For more info see: https://daringfireball.net/projects/markdown/syntax#p