### PR TITLE
[PROPOSAL] Change current timezone in Slack

### DIFF
--- a/remote/remote_guidelines.md
+++ b/remote/remote_guidelines.md
@@ -12,3 +12,5 @@ When you are working remote please update your Slack status (using the house ico
 
 <img src="images/remote_screenshot_2.png" width="450">
 
+
+If you are abroad, update your Time Zone in `Profile & account > Edit Profile > Time Zone` so other people know which is your current time. Alternatively, you can just click on your name on any of your messages and click on _Edit your profile_.


### PR DESCRIPTION
If someone is working remote in a different country, knowing which is their current time might be difficult, specially if that country has several time zones.

This proposes that people change its time zone so just by clicking on them in Slack anyone can know the current time in the remote location.