### PR TITLE
Update licensing.md

### DIFF
--- a/engineering/licensing.md
+++ b/engineering/licensing.md
@@ -11,7 +11,7 @@ following rules.
 At the time of creating a new project you can choose between two different
 licenses:
 
-- [GPL v3.0](https://www.gnu.org/licenses/gpl.html), applied to projects whose nature is specific to language analysis, machine learning and other core parts of our stack and may be used through a client library owned by us, allowing interaction with the project to third-party propietary code.
+- [GPL v3.0](https://www.gnu.org/licenses/gpl.html), applied to projects whose nature is specific to language analysis, machine learning and other core parts of our stack and may be used through a client library owned by us, allowing interaction with the project to third-party proprietary code.
 
 
 - [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), this license should be applied to projects which are libraries or tools that require direct interaction with third-party code, which the GPLv3 and variants doesn't allow. _Some examples are: bblfsh/server or bblfsh/*-driver_
@@ -30,7 +30,7 @@ To learn more about DCO please read:
 - [Developer Certificate of Origin versus Contributor License Agreements](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/)
 
 
-## Resources
+## Templates
 
 - [GPL v3.0 License](documents/gpl/LICENSE) Document
 - [Apache License 2.0](documents/apache/LICENSE) Document

--- a/engineering/licensing.md
+++ b/engineering/licensing.md
@@ -18,6 +18,9 @@ licenses:
 
 > Variants of GPLv3, such as AGPLv3 or LGPLv3 can be used under request and on a per case basis.
 
+## Re-license
+In case if a code is copied between src-d projects covered by different licenses, src-d emploees are entitled to relicense the code as needed among those projects, if all the code was written by src-d emploees. THIS CANNOT BE DONE WITH 3RD PARTY CODE.
+
 ## Developer Certificate of Origin
 
 All our projects should include a [Developer Certificate of Origin](https://developercertificate.org/) (DCO) document to protect us against any individual contributor revoking our rights to distribute their contribution to any of our projects.

--- a/engineering/licensing.md
+++ b/engineering/licensing.md
@@ -19,7 +19,7 @@ licenses:
 > Variants of GPLv3, such as AGPLv3 or LGPLv3 can be used under request and on a per case basis.
 
 ## Re-license
-In case if a code is copied between src-d projects covered by different licenses, src-d emploees are entitled to relicense the code as needed among those projects, if all the code was written by src-d emploees. THIS CANNOT BE DONE WITH 3RD PARTY CODE.
+In case if a code is copied between src-d projects covered by different licenses, src-d employees are entitled to relicense the code as needed among those projects, if all the code was written by src-d employees. THIS CANNOT BE DONE WITH 3RD PARTY CODE.
 
 ## Developer Certificate of Origin
 

--- a/engineering/licensing.md
+++ b/engineering/licensing.md
@@ -11,10 +11,10 @@ following rules.
 At the time of creating a new project you can choose between two different
 licenses:
 
-- [GPL v3.0](https://www.gnu.org/licenses/gpl.html), applied to projects whose nature is specific to language analysis, machine learning and other core parts of our stack and may be used through a client library owned by us, allowing interaction with the project to third-party proprietary code.
+- [GPL v3.0](https://www.gnu.org/licenses/gpl.html), applied to all projects whose nature is specific to core parts of our stack like language analysis, machine learning, etc. and which are mostly applications and are intended to be consumed through a separate client library owned by us. This allows clean interaction to third-party proprietary code. _Examples: bblfsh/server, bblfsh/*-driver_
 
 
-- [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), this license should be applied to projects which are libraries or tools that require direct interaction with third-party code, which the GPLv3 and variants doesn't allow. _Some examples are: bblfsh/server or bblfsh/*-driver_
+- [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), this license should be applied to projects which are libraries or tools that intended to be consumed by third-parties as a sourced code dependencies, which the GPLv3 and variants doesn't allow (if consumers are not GPL). _Some examples are: bblfsh/*-client_
 
 > Variants of GPLv3, such as AGPLv3 or LGPLv3 can be used under request and on a per case basis.
 

--- a/engineering/licensing.md
+++ b/engineering/licensing.md
@@ -14,7 +14,7 @@ licenses:
 - [GPL v3.0](https://www.gnu.org/licenses/gpl.html), applied to all projects whose nature is specific to core parts of our stack like language analysis, machine learning, etc. and which are mostly applications and are intended to be consumed through a separate client library owned by us. This allows clean interaction to third-party proprietary code. _Examples: bblfsh/server, bblfsh/*-driver_
 
 
-- [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), this license should be applied to projects which are libraries or tools that intended to be consumed by third-parties as a sourced code dependencies, which the GPLv3 and variants doesn't allow (if consumers are not GPL). _Some examples are: bblfsh/*-client_
+- [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), this license should be applied to projects which are libraries or tools that intended to be consumed by third-parties as a source code dependencies, which the GPLv3 and variants doesn't allow (if consumers are not GPL). _Some examples are: bblfsh/*-client_
 
 > Variants of GPLv3, such as AGPLv3 or LGPLv3 can be used under request and on a per case basis.
 


### PR DESCRIPTION
 - [x] fixing a typo
 - [x] add note on re-licensing between src-d projects
 - [x] update wording for Apache/GPL licensing guide for projects, as [decided on retrospective](https://github.com/src-d/minutes/pull/35/files#diff-89b474f52e6f6b530e7dca2e343dcb64R29)