### PR TITLE
developer-community: update event list

### DIFF
--- a/developer-community/events-list.md
+++ b/developer-community/events-list.md
@@ -104,6 +104,13 @@
 |---------------------------------|-------------|-------------|-------------|
 |[POPL](http://popl18.sigplan.org/) |LA         |             |             |
 
+## February 2018
+
+|Conference                       |Location     |Status       |Topic        |
+|---------------------------------|-------------|-------------|-------------|
+|[FOSDEM](https://fosdem.org/2018/) |Brussles   | CFP Open. Co-host Golang & [SrcAnalysis](http://source-code-analysis-fosdem.github.io/) DevRooms   |Bblfsh,Engine|
+
+
 ## April 2018
 
 |Conference                       |Location     |Status       |Topic        |

--- a/developer-community/events-list.md
+++ b/developer-community/events-list.md
@@ -80,10 +80,12 @@
 
 |Conference                       |Location     |Status       |Topic        |
 |---------------------------------|-------------|-------------|-------------|
+| South Summit | Madrid | Speakers 🚀 | [The Future of AI on Code](https://docs.google.com/presentation/d/e/2PACX-1vTJWV87a9LEqbWfsFTG55xVwbLygxNdOqM0o-0DLdzhmdaCf-XuuOMETbXGEJrryvHviuH2xeioQbsg/pub?start=false&loop=false&delayms=3000) |
 |[MCubed](http://www.mcubed.london/)|London     |Speakers :rocket: |High-dimensional Data|
 |[PyCon UK](http://2017.pyconuk.org/)|Cardiff   |             |             |
 |[GitHubUniverse](https://githubuniverse.com/)|SF|CFP Open    |             |
 |[DockerCon EU](https://europe-2017.dockercon.com/)| Multiple |       |     |
+| Open Source Summit Europe | Prague | Speakers 🚀 | [source{d} stack + licensing app](https://docs.google.com/presentation/d/e/2PACX-1vRExSOGd2Pmz2oV237bfqwHyPyW8Yg2rydmdt8oSPZC3_uM0SnA5BTORxT9J52ONCtbNOf5CzfN0ZaT/pub?start=false&loop=false&delayms=3000) |
 
 ## November
 

--- a/developer-community/events-list.md
+++ b/developer-community/events-list.md
@@ -89,7 +89,9 @@
 
 |Conference                       |Location     |Status       |Topic        |
 |---------------------------------|-------------|-------------|-------------|
-|[DotGo](https://www.dotgo.io/)   |Paris        |CFP Submitted|             |
+|[DotGo](https://www.dotgo.io/)   |Paris        |Speakers :rockt:|          |
+|[AIFORSE](http://archive.is/VHgeP)|Barcelona   |Speakers/sponsors :rockt:| [src-d stack + background](https://docs.google.com/presentation/d/1LGt8MdoBmgxOAujn8xGTT_KmZRDXPI2Fv_8Na1xWYHg/edit)|
+
 
 ## December
 


### PR DESCRIPTION
The list of events, past and upcoming is a bit stale, this brings

 - [x] AIFORSE
 - [x] FOSDEM2018
 - [x] South Summit
 - [x] Open Source Summit Europe

initiatives here. 

Looking forward a better maintained list of upcoming/past event materials in the future, since @campoy joined! 🚀 