### PR TITLE
Licensing: fix broken link

### DIFF
--- a/engineering/licensing.md
+++ b/engineering/licensing.md
@@ -37,4 +37,4 @@ To learn more about DCO please read:
 
 - [GPL v3.0 License](documents/gpl/LICENSE) Document
 - [Apache License 2.0](documents/apache/LICENSE) Document
-- [Developer Certificate of Origin](documents/gpl/DCO) Document
+- [Developer Certificate of Origin](documents/DCO) Document


### PR DESCRIPTION
A link to DCO template was pointing to the wrong dir.