### PR TITLE
Add intern/senior ML job descriptions

### DIFF
--- a/talent/job-descriptions/intern-ds.md
+++ b/talent/job-descriptions/intern-ds.md
@@ -6,7 +6,7 @@
 
 ## TEAM
 
-- The Data Science team is focused on providing intelligent insights into nearly all the world's open source code. This includes typical big data analysis as well as solving sophisticated Machine Learning problems. The former is conducted on Apache Spark clusters with up to 1,000 nodes, the latter leverage extensive GPGPU acceleration on the custom hardware and Deep Learning techniques, standing on top of source{d}'s original open source projects and Tensorflow. Often, arising ML problems are unsupervised and require much research in the unusual domain of ML on source code (MLoSC).
+- The Machine Learning team is focused on providing intelligent insights into nearly all the world's open source code. This includes typical big data analysis as well as solving sophisticated Machine Learning problems. The former is conducted on Apache Spark clusters with up to 1,000 nodes, the latter leverage extensive GPGPU acceleration on the custom hardware and Deep Learning techniques, standing on top of source{d}'s original open source projects and Tensorflow. Often, arising ML problems are unsupervised and require much research in the unusual domain of ML on source code (MLoSC).
 
 - source{d} tries to be as open in it's ongoing research as possible. If a handy developed tool can be open-sourced then it has to be. If a solved interesting problem can be disclosed, it has to be published in source{d}'s blog. If a funny dataset is compiled, it is published on data.world. Writing papers is welcomed. We talk on conferences literally every month.
 

--- a/talent/job-descriptions/intern-ds.md
+++ b/talent/job-descriptions/intern-ds.md
@@ -10,34 +10,55 @@
 
 - source{d} tries to be as open in it's ongoing research as possible. If a handy developed tool can be open-sourced then it has to be. If a solved interesting problem can be disclosed, it has to be published in source{d}'s blog. If a funny dataset is compiled, it is published on data.world. Writing papers is welcomed. We talk on conferences literally every month.
 
-- To this moment, source{d}'s engineers have developed:
-- src-d/awesome-machine-learning-on-source-code - everything that we know about MLoSC.
-- ml - MLoSC framework.
-- apollo - modular source code de-duplication research project.
-- kmcuda - lightning fast K-means and K-nearest neighbours on NVIDIA GPUs. It allows us to cluster 3 million samples, each 256 dimensions, into 1000 clusters in less than 20 minutes with the outstanding precision using two NVIDIA Titan X cards.
-- minhashcuda - lightning fast Weighted MinHash on NVIDIA GPUs. This tool allowed us to scan all +17M git repositories in 30 minutes and find 1.5M duplicates (the results were
-published on data.world.
-- lapjv - Jonker-Volgenant algorithm to solve linear sum assignment problems, accelerated with Intel AVX2 instruction set. It is capable of transforming 4096 t-SNE dots into 64x64 images in 2 minutes.
-- wmd-relax - optimized Word Mover's Distance
-- hercules - Git repositories line burn down analysis command line tool built on top of source{d}'s go-git - Git client and server implementation in pure Go language.
-- sparkpickle - the tool to read PySpar RDD files without having to install Spark.
+### To this moment, source{d}'s engineers have developed:
+
+- [src-d/awesome-machine-learning-on-source-code](https://github.com/src-d/awesome-machine-learning-on-source-code): everything that we know about MLoSC.
+
+- [ml](https://github.com/src-d/ml): MLoSC framework.
+
+- [apollo](https://github.com/src-d/apollo): modular source code de-duplication research project.
+
+- [kmcuda](https://github.com/src-d/kmcuda): lightning fast K-means and K-nearest neighbours on NVIDIA GPUs. It allows us to cluster 3 million samples, each 256 dimensions, into 1000 clusters in less than 20 minutes with the outstanding precision using two NVIDIA Titan X cards.
+
+- [minhashcuda](https://github.com/src-d/minhashcuda): lightning fast Weighted MinHash on NVIDIA GPUs. This tool allowed us to scan all +17M git repositories in 30 minutes and find [1.5M](http://1.5m/) duplicates. The results were published on [data.world](https://data.world/vmarkovtsev/github-duplicate-repositories).
+
+- [lapjv](https://github.com/src-d/lapjv): Jonker-Volgenant algorithm to solve linear sum assignment problems, accelerated with Intel AVX2 instruction set. It is capable of transforming 4096 t-SNE dots into 64x64 images in 2 minutes.
+
+- [wmd-relax](https://github.com/src-d/wmd-relax): optimized Word Mover's Distance
+
+- [hercules](https://github.com/src-d/hercules): Git repositories line burn down analysis command line tool built on top of source{d}'s [go-git](https://github.com/src-d/go-git), a Git client and server implementation in pure Go language.
+
+- [sparkpickle](https://github.com/src-d/sparkpickle): the tool to read PySpar RDD files without having to install Spark.
 
 ### The following notable technical posts, papers and talks exist:
-- Source Code Identifier Embeddings
-- Open Source Stack for Machine Learning on Source Code
-- Analyzing GitHub, How Developers Change Programming Languages Over Time
-- GitHub Contributions Graph: Analyzing Pagerank & Proving the 6 Handshakes Theory
-- Similarity of GitHub Repositories by Source Code Identifiers
-- 397 Languages, 18,000,000 GitHub repositories, 1.2 billion files, 20 terabytes of code: Spaces or Tabs
-- Topic modeling of public repositories at scale using names in source code - paper
-- Hands on with the most starred GitHub repositories
-- Source code abstracts classification using CNN
+
+- [Source Code Identifier Embeddings](https://blog.sourced.tech/post/id2vec/)
+
+- [Open Source Stack for Machine Learning on Source Code](http://vmarkovtsev.github.io/gdg-2017-berlin/)
+
+- [Analyzing GitHub, How Developers Change Programming Languages Over Time](https://blog.sourced.tech/post/language_migrations/)
+
+- [GitHub Contributions Graph: Analyzing Pagerank & Proving the 6 Handshakes Theory](https://blog.sourced.tech/post/handshakes_pagerank/)
+
+- [Similarity of GitHub Repositories by Source Code Identifiers](http://vmarkovtsev.github.io/techtalks-2017-moscow/)
+
+- [397 Languages, 18,000,000 GitHub repositories, 1.2 billion files, 20 terabytes of code: Spaces or Tabs](https://blog.sourced.tech/post/tab_vs_spaces/)
+
+- [Topic modeling of public repositories at scale using names in source code](https://arxiv.org/abs/1704.00135) - paper
+
+- [Hands on with the most starred GitHub repositories](https://blog.sourced.tech/post/github_stars/)
+
+- [Source code abstracts classification using CNN](http://vmarkovtsev.github.io/slush-2016/)
 
 ### The following datasets published:
-- Names in source code extracted from 13 000 000 GitHub repositories. Not people! 30GB
-- October 2016 GitHub repositories not marked as forks but very similar to each other
-- Readme files found in all GitHub repositories (16M, October 2016
-- ≈ 452,000,000 commits' metadata taken from 16,000,000 repositories on GitHub (Oct 2016)
+
+- [Names in source code extracted from 13 000 000 GitHub repositories. Not people! 30GB](https://data.world/vmarkovtsev/github-source-code-names)
+
+- [October 2016 GitHub repositories not marked as forks but very similar to each other](https://data.world/vmarkovtsev/github-duplicate-repositories)
+
+- [Readme files found in all GitHub repositories (16M, October 2016](https://data.world/vmarkovtsev/github-readme-files)
+
+- [≈ 452,000,000 commits' metadata taken from 16,000,000 repositories on GitHub (Oct 2016)](https://data.world/vmarkovtsev/452-m-commits-on-github)
 
 
 ## ROLE

--- a/talent/job-descriptions/intern-ds.md
+++ b/talent/job-descriptions/intern-ds.md
@@ -1,0 +1,68 @@
+- At source{d} we are building the stack for the next generation of Machine Learning powered developer tools.
+
+- We have raised over eight million USD so far, and we are currently growing our team.
+
+- Our current monetization strategy is based on deploying our stack and tooling within large tech companies.
+
+## TEAM
+
+- The Data Science team is focused on providing intelligent insights into nearly all the world's open source code. This includes typical big data analysis as well as solving sophisticated Machine Learning problems. The former is conducted on Apache Spark clusters with up to 1,000 nodes, the latter leverage extensive GPGPU acceleration on the custom hardware and Deep Learning techniques, standing on top of source{d}'s original open source projects and Tensorflow. Often, arising ML problems are unsupervised and require much research in the unusual domain of ML on source code (MLoSC).
+
+- source{d} tries to be as open in it's ongoing research as possible. If a handy developed tool can be open-sourced then it has to be. If a solved interesting problem can be disclosed, it has to be published in source{d}'s blog. If a funny dataset is compiled, it is published on data.world. Writing papers is welcomed. We talk on conferences literally every month.
+
+- To this moment, source{d}'s engineers have developed:
+- src-d/awesome-machine-learning-on-source-code - everything that we know about MLoSC.
+- ml - MLoSC framework.
+- apollo - modular source code de-duplication research project.
+- kmcuda - lightning fast K-means and K-nearest neighbours on NVIDIA GPUs. It allows us to cluster 3 million samples, each 256 dimensions, into 1000 clusters in less than 20 minutes with the outstanding precision using two NVIDIA Titan X cards.
+- minhashcuda - lightning fast Weighted MinHash on NVIDIA GPUs. This tool allowed us to scan all +17M git repositories in 30 minutes and find 1.5M duplicates (the results were
+published on data.world.
+- lapjv - Jonker-Volgenant algorithm to solve linear sum assignment problems, accelerated with Intel AVX2 instruction set. It is capable of transforming 4096 t-SNE dots into 64x64 images in 2 minutes.
+- wmd-relax - optimized Word Mover's Distance
+- hercules - Git repositories line burn down analysis command line tool built on top of source{d}'s go-git - Git client and server implementation in pure Go language.
+• sparkpickle - the tool to read PySpar RDD files without having to install Spark.
+
+### The following notable technical posts, papers and talks exist:
+- Source Code Identifier Embeddings
+- Open Source Stack for Machine Learning on Source Code
+- Analyzing GitHub, How Developers Change Programming Languages Over Time
+- GitHub Contributions Graph: Analyzing Pagerank & Proving the 6 Handshakes Theory
+- Similarity of GitHub Repositories by Source Code Identifiers
+- 397 Languages, 18,000,000 GitHub repositories, 1.2 billion files, 20 terabytes of code: Spaces or Tabs
+- Topic modeling of public repositories at scale using names in source code - paper
+- Hands on with the most starred GitHub repositories
+- Source code abstracts classification using CNN
+
+### The following datasets published:
+- Names in source code extracted from 13 000 000 GitHub repositories. Not people! 30GB
+- October 2016 GitHub repositories not marked as forks but very similar to each other
+- Readme files found in all GitHub repositories (16M, October 2016
+- ≈ 452,000,000 commits' metadata taken from 16,000,000 repositories on GitHub (Oct 2016)
+
+
+ROLE
+
+- Strong computer science and machine learning background is essential for data science team members. You will be expected to be a passionate, skilful engineer who is able to produce amazing results quickly and reliably. Coding skills are important; we are using Python 3 in our research and production prototyping. Besides, we occasionally code in Go, C++ and CUDA.
+
+
+## CULTURE
+
+- source{d} is a company for developers by developers. We firmly believe in always doing what's best for the community, not necessarily companies. "For developers" is the answer to any strategic question or dilemma in the company. Always For Developers.
+
+- "By developers" is our identity. Everyone in the company is either a developer or has a developer/engineering mindset. We don't hire anyone who doesn't fit into this culture, it's the only way to make sure everyone understands developers and can always defend their interest.
+
+- At the moment, we are 20+ people from 10 different countries working closely together from our office in Madrid, Spain. We are more than happy to sponsor you a visa and guide you and your family through the whole process if you decide to come to work from our office, but you may also choose to work remotely as part of our team does working from Portugal, Estonia, Russia, and others.
+
+- Following the same level of transparency as with development process, all the above aspects of the work culture are documented and publicly available in our Guide at https://github.com/src-d/guide/.
+
+## PERKS 
+
+ - EU Visa support.
+ - Open Source Days, 10% of the time you can work on any OSS project you choose.
+ - Flexible hours and the possibility of remote work.
+ - We go to conferences and other developer events ! ;)
+ - Free books. Company will buy any books that can help you be even better at your work.
+ - Spacious physical office, close to public transit and to the Retiro park.
+ - Kitchen, full of supplies from beers to fresh fruits.
+ - Monthly get-togethers, annual summer and winter Xmas parties, a retreat.
+ - Our own, open source craft beers src-d/homebrew.

--- a/talent/job-descriptions/intern-ds.md
+++ b/talent/job-descriptions/intern-ds.md
@@ -6,7 +6,7 @@
 
 ## TEAM
 
-- The Machine Learning team is focused on providing intelligent insights into nearly all the world's open source code. This includes typical big data analysis as well as solving sophisticated Machine Learning problems. The former is conducted on Apache Spark clusters with up to 1,000 nodes, the latter leverage extensive GPGPU acceleration on the custom hardware and Deep Learning techniques, standing on top of source{d}'s original open source projects and Tensorflow. Often, arising ML problems are unsupervised and require much research in the unusual domain of ML on source code (MLoSC).
+- The Machine Learning team is focused on providing intelligent insights into nearly all the world's open source code. This includes typical big data analysis as well as solving sophisticated Machine Learning problems. The former is conducted on Apache Spark clusters with up to 1,000 nodes, the latter leverages extensive GPGPU acceleration on the custom hardware and Deep Learning techniques, standing on top of source{d}'s original open source projects and Tensorflow. Often, arising ML problems are unsupervised and require much research in the unusual domain of ML on source code (MLoSC).
 
 - source{d} tries to be as open in it's ongoing research as possible. If a handy developed tool can be open-sourced then it has to be. If a solved interesting problem can be disclosed, it has to be published in source{d}'s blog. If a funny dataset is compiled, it is published on data.world. Writing papers is welcomed. We talk on conferences literally every month.
 
@@ -20,7 +20,7 @@ published on data.world.
 - lapjv - Jonker-Volgenant algorithm to solve linear sum assignment problems, accelerated with Intel AVX2 instruction set. It is capable of transforming 4096 t-SNE dots into 64x64 images in 2 minutes.
 - wmd-relax - optimized Word Mover's Distance
 - hercules - Git repositories line burn down analysis command line tool built on top of source{d}'s go-git - Git client and server implementation in pure Go language.
-• sparkpickle - the tool to read PySpar RDD files without having to install Spark.
+- sparkpickle - the tool to read PySpar RDD files without having to install Spark.
 
 ### The following notable technical posts, papers and talks exist:
 - Source Code Identifier Embeddings
@@ -40,10 +40,9 @@ published on data.world.
 - ≈ 452,000,000 commits' metadata taken from 16,000,000 repositories on GitHub (Oct 2016)
 
 
-ROLE
+## ROLE
 
-- Strong computer science and machine learning background is essential for data science team members. You will be expected to be a passionate, skilful engineer who is able to produce amazing results quickly and reliably. Coding skills are important; we are using Python 3 in our research and production prototyping. Besides, we occasionally code in Go, C++ and CUDA.
-
+- Strong computer science and machine learning background is essential for data science team members. You will be expected to be a passionate, skilful engineer who is able to produce amazing results quickly and reliably. Coding skills are important; we are using Python 3 in our research and production prototyping. Besides, we occasionally code in Go, C++ and CUDA. MLoSC shares common ideas with Natural Language Processing, so solid **NLP** knowledge is also required. **Deep Learning** experience is highly appreciated.
 
 ## CULTURE
 

--- a/talent/job-descriptions/senior-ds.md
+++ b/talent/job-descriptions/senior-ds.md
@@ -52,13 +52,13 @@
 
 ### The following datasets published:
 
-- [Names in source code extracted from 13 000 000 GitHub repositories. Not people! 30GB](https://data.world/vmarkovtsev/github-source-code-names)
+- [Names in source code extracted from 13 000 000 GitHub repositories. Not people! 30GB](https://data.world/vmarkovtsev/github-source-code-names)
 
-- [October 2016 GitHub repositories not marked as forks but very similar to each other](https://data.world/vmarkovtsev/github-duplicate-repositories)
+- [October 2016 GitHub repositories not marked as forks but very similar to each other](https://data.world/vmarkovtsev/github-duplicate-repositories)
 
-- [Readme files found in all GitHub repositories (16M, October 2016](https://data.world/vmarkovtsev/github-readme-files)
+- [Readme files found in all GitHub repositories (16M, October 2016](https://data.world/vmarkovtsev/github-readme-files)
 
-- [≈ 452,000,000 commits' metadata taken from 16,000,000 repositories on GitHub (Oct 2016)](https://data.world/vmarkovtsev/452-m-commits-on-github)
+- [≈ 452,000,000 commits' metadata taken from 16,000,000 repositories on GitHub (Oct 2016)](https://data.world/vmarkovtsev/452-m-commits-on-github)
 
 
 ### ROLE

--- a/talent/job-descriptions/senior-ds.md
+++ b/talent/job-descriptions/senior-ds.md
@@ -6,7 +6,7 @@
 
 ## TEAM
 
-- The Data Science team is focused on providing intelligent insights into nearly all the world's open source code. This includes typical big data analysis as well as solving sophisticated Machine Learning problems. The former is conducted on Apache Spark clusters with up to 1,000 nodes, the latter leverage extensive GPGPU acceleration on the custom hardware and Deep Learning techniques, standing on top of source{d}'s original open source projects and Tensorflow. Often, arising ML problems are unsupervised and require much research in the unusual domain of ML on source code (MLoSC).
+- The Machine Learning team is focused on providing intelligent insights into nearly all the world's open source code. This includes typical big data analysis as well as solving sophisticated Machine Learning problems. The former is conducted on Apache Spark clusters with up to 1,000 nodes, the latter leverage extensive GPGPU acceleration on the custom hardware and Deep Learning techniques, standing on top of source{d}'s original open source projects and Tensorflow. Often, arising ML problems are unsupervised and require much research in the unusual domain of ML on source code (MLoSC).
 
 - source{d} tries to be as open in it's ongoing research as possible. If a handy developed tool can be open-sourced then it has to be. If a solved interesting problem can be disclosed, it has to be published in source{d}'s blog. If a funny dataset is compiled, it is published on data.world. Writing papers is welcomed. We talk on conferences literally every month.
 

--- a/talent/job-descriptions/senior-ds.md
+++ b/talent/job-descriptions/senior-ds.md
@@ -10,34 +10,55 @@
 
 - source{d} tries to be as open in it's ongoing research as possible. If a handy developed tool can be open-sourced then it has to be. If a solved interesting problem can be disclosed, it has to be published in source{d}'s blog. If a funny dataset is compiled, it is published on data.world. Writing papers is welcomed. We talk on conferences literally every month.
 
-- To this moment, source{d}'s engineers have developed:
-- src-d/awesome-machine-learning-on-source-code: everything that we know about MLoSC.
-- ml: MLoSC framework.
-- apollo: modular source code de-duplication research project.
-- kmcuda: lightning fast K-means and K-nearest neighbours on NVIDIA GPUs. It allows us to cluster 3 million samples, each 256 dimensions, into 1000 clusters in less than 20 minutes with the outstanding precision using two NVIDIA Titan X cards.
-- minhashcuda: lightning fast Weighted MinHash on NVIDIA GPUs. This tool allowed us to scan all +17M git repositories in 30 minutes and find 1.5M duplicates (the results were
-published on data.world.
-- lapjv: Jonker-Volgenant algorithm to solve linear sum assignment problems, accelerated with Intel AVX2 instruction set. It is capable of transforming 4096 t-SNE dots into 64x64 images in 2 minutes.
-- wmd-relax: optimized Word Mover's Distance
-- hercules: Git repositories line burn down analysis command line tool built on top of source{d}'s go-git - Git client and server implementation in pure Go language.
-- sparkpickle: the tool to read PySpar RDD files without having to install Spark.
+### To this moment, source{d}'s engineers have developed:
+
+- [src-d/awesome-machine-learning-on-source-code](https://github.com/src-d/awesome-machine-learning-on-source-code): everything that we know about MLoSC.
+
+- [ml](https://github.com/src-d/ml): MLoSC framework.
+
+- [apollo](https://github.com/src-d/apollo): modular source code de-duplication research project.
+
+- [kmcuda](https://github.com/src-d/kmcuda): lightning fast K-means and K-nearest neighbours on NVIDIA GPUs. It allows us to cluster 3 million samples, each 256 dimensions, into 1000 clusters in less than 20 minutes with the outstanding precision using two NVIDIA Titan X cards.
+
+- [minhashcuda](https://github.com/src-d/minhashcuda): lightning fast Weighted MinHash on NVIDIA GPUs. This tool allowed us to scan all +17M git repositories in 30 minutes and find [1.5M](http://1.5m/) duplicates. The results were published on [data.world](https://data.world/vmarkovtsev/github-duplicate-repositories).
+
+- [lapjv](https://github.com/src-d/lapjv): Jonker-Volgenant algorithm to solve linear sum assignment problems, accelerated with Intel AVX2 instruction set. It is capable of transforming 4096 t-SNE dots into 64x64 images in 2 minutes.
+
+- [wmd-relax](https://github.com/src-d/wmd-relax): optimized Word Mover's Distance
+
+- [hercules](https://github.com/src-d/hercules): Git repositories line burn down analysis command line tool built on top of source{d}'s [go-git](https://github.com/src-d/go-git), a Git client and server implementation in pure Go language.
+
+- [sparkpickle](https://github.com/src-d/sparkpickle): the tool to read PySpar RDD files without having to install Spark.
 
 ### The following notable technical posts, papers and talks exist:
-- Source Code Identifier Embeddings
-- Open Source Stack for Machine Learning on Source Code
-- Analyzing GitHub, How Developers Change Programming Languages Over Time
-- GitHub Contributions Graph: Analyzing Pagerank & Proving the 6 Handshakes Theory
-- Similarity of GitHub Repositories by Source Code Identifiers
-- 397 Languages, 18,000,000 GitHub repositories, 1.2 billion files, 20 terabytes of code: Spaces or Tabs
-- Topic modeling of public repositories at scale using names in source code - paper
-- Hands on with the most starred GitHub repositories
-- Source code abstracts classification using CNN
+
+- [Source Code Identifier Embeddings](https://blog.sourced.tech/post/id2vec/)
+
+- [Open Source Stack for Machine Learning on Source Code](http://vmarkovtsev.github.io/gdg-2017-berlin/)
+
+- [Analyzing GitHub, How Developers Change Programming Languages Over Time](https://blog.sourced.tech/post/language_migrations/)
+
+- [GitHub Contributions Graph: Analyzing Pagerank & Proving the 6 Handshakes Theory](https://blog.sourced.tech/post/handshakes_pagerank/)
+
+- [Similarity of GitHub Repositories by Source Code Identifiers](http://vmarkovtsev.github.io/techtalks-2017-moscow/)
+
+- [397 Languages, 18,000,000 GitHub repositories, 1.2 billion files, 20 terabytes of code: Spaces or Tabs](https://blog.sourced.tech/post/tab_vs_spaces/)
+
+- [Topic modeling of public repositories at scale using names in source code](https://arxiv.org/abs/1704.00135) - paper
+
+- [Hands on with the most starred GitHub repositories](https://blog.sourced.tech/post/github_stars/)
+
+- [Source code abstracts classification using CNN](http://vmarkovtsev.github.io/slush-2016/)
 
 ### The following datasets published:
-- Names in source code extracted from 13 000 000 GitHub repositories. Not people! 30GB
-- October 2016 GitHub repositories not marked as forks but very similar to each other
-- Readme files found in all GitHub repositories (16M, October 2016
-- ≈ 452,000,000 commits' metadata taken from 16,000,000 repositories on GitHub (Oct 2016)
+
+- [Names in source code extracted from 13 000 000 GitHub repositories. Not people! 30GB](https://data.world/vmarkovtsev/github-source-code-names)
+
+- [October 2016 GitHub repositories not marked as forks but very similar to each other](https://data.world/vmarkovtsev/github-duplicate-repositories)
+
+- [Readme files found in all GitHub repositories (16M, October 2016](https://data.world/vmarkovtsev/github-readme-files)
+
+- [≈ 452,000,000 commits' metadata taken from 16,000,000 repositories on GitHub (Oct 2016)](https://data.world/vmarkovtsev/452-m-commits-on-github)
 
 
 ### ROLE

--- a/talent/job-descriptions/senior-ds.md
+++ b/talent/job-descriptions/senior-ds.md
@@ -6,21 +6,21 @@
 
 ## TEAM
 
-- The Machine Learning team is focused on providing intelligent insights into nearly all the world's open source code. This includes typical big data analysis as well as solving sophisticated Machine Learning problems. The former is conducted on Apache Spark clusters with up to 1,000 nodes, the latter leverage extensive GPGPU acceleration on the custom hardware and Deep Learning techniques, standing on top of source{d}'s original open source projects and Tensorflow. Often, arising ML problems are unsupervised and require much research in the unusual domain of ML on source code (MLoSC).
+- The Machine Learning team is focused on providing intelligent insights into nearly all the world's open source code. This includes typical big data analysis as well as solving sophisticated Machine Learning problems. The former is conducted on Apache Spark clusters with up to 1,000 nodes, the latter leverages extensive GPGPU acceleration on the custom hardware and Deep Learning techniques, standing on top of source{d}'s original open source projects and Tensorflow. Often, arising ML problems are unsupervised and require much research in the unusual domain of ML on source code (MLoSC).
 
 - source{d} tries to be as open in it's ongoing research as possible. If a handy developed tool can be open-sourced then it has to be. If a solved interesting problem can be disclosed, it has to be published in source{d}'s blog. If a funny dataset is compiled, it is published on data.world. Writing papers is welcomed. We talk on conferences literally every month.
 
 - To this moment, source{d}'s engineers have developed:
-- src-d/awesome-machine-learning-on-source-code - everything that we know about MLoSC.
-- ml - MLoSC framework.
-- apollo - modular source code de-duplication research project.
-- kmcuda - lightning fast K-means and K-nearest neighbours on NVIDIA GPUs. It allows us to cluster 3 million samples, each 256 dimensions, into 1000 clusters in less than 20 minutes with the outstanding precision using two NVIDIA Titan X cards.
+- src-d/awesome-machine-learning-on-source-code: everything that we know about MLoSC.
+- ml: MLoSC framework.
+- apollo: modular source code de-duplication research project.
+- kmcuda: lightning fast K-means and K-nearest neighbours on NVIDIA GPUs. It allows us to cluster 3 million samples, each 256 dimensions, into 1000 clusters in less than 20 minutes with the outstanding precision using two NVIDIA Titan X cards.
 - minhashcuda - lightning fast Weighted MinHash on NVIDIA GPUs. This tool allowed us to scan all +17M git repositories in 30 minutes and find 1.5M duplicates (the results were
 published on data.world.
-- lapjv - Jonker-Volgenant algorithm to solve linear sum assignment problems, accelerated with Intel AVX2 instruction set. It is capable of transforming 4096 t-SNE dots into 64x64 images in 2 minutes.
-- wmd-relax - optimized Word Mover's Distance
-- hercules - Git repositories line burn down analysis command line tool built on top of source{d}'s go-git - Git client and server implementation in pure Go language.
-• sparkpickle - the tool to read PySpar RDD files without having to install Spark.
+- lapjv: Jonker-Volgenant algorithm to solve linear sum assignment problems, accelerated with Intel AVX2 instruction set. It is capable of transforming 4096 t-SNE dots into 64x64 images in 2 minutes.
+- wmd-relax: optimized Word Mover's Distance
+- hercules: Git repositories line burn down analysis command line tool built on top of source{d}'s go-git - Git client and server implementation in pure Go language.
+- sparkpickle: the tool to read PySpar RDD files without having to install Spark.
 
 ### The following notable technical posts, papers and talks exist:
 - Source Code Identifier Embeddings
@@ -40,9 +40,9 @@ published on data.world.
 - ≈ 452,000,000 commits' metadata taken from 16,000,000 repositories on GitHub (Oct 2016)
 
 
-ROLE
+### ROLE
 
-- Strong computer science and machine learning background is essential for data science team members. You will be expected to be a passionate, skillful engineer who is able to produce amazing results quickly and reliably. Coding skills are important; we are using Python 3 and Go in our research and production prototyping. Besides, we occasionally code in C++ and CUDA. MLoSC shares common ideas with Natural Language Processing, so solid NLP knowledge is also required. Deep Learning experience is highly appreciated.
+- Strong computer science and machine learning background is essential for data science team members. You will be expected to be a passionate, skillful engineer who is able to produce amazing results quickly and reliably. Coding skills are important; we are using Python 3 and Go in our research and production prototyping. Besides, we occasionally code in C++ and CUDA. MLoSC shares common ideas with Natural Language Processing, so solid **NLP** knowledge is also required. **Deep Learning experience** is highly appreciated.
 
 
 ## CULTURE
@@ -68,3 +68,4 @@ ROLE
  - Kitchen, full of supplies from beers to fresh fruits.
  - Monthly get-togethers, annual summer and winter Xmas parties, a retreat.
  - Our own, open source craft beers src-d/homebrew.
+ 

--- a/talent/job-descriptions/senior-ds.md
+++ b/talent/job-descriptions/senior-ds.md
@@ -74,7 +74,7 @@
 
 - At the moment, we are 20+ people from 10 different countries working closely together from our office in Madrid, Spain. We are more than happy to sponsor you a visa and guide you and your family through the whole process if you decide to come to work from our office, but you may also choose to work remotely as part of our team does working from Portugal, Estonia, Russia, and others.
 
-- At source{d}, we have a transparent salary policy which we feel strongly about it. Although a seniority level for every candidate will be determined during the last round of on-site interviews, one can expect that for a Senior Engineer salary ranges from €49.000 to €53.000. You can find our net amounts [here](https://cincodias.elpais.com/herramientas/calculadora-sueldo-neto/) (in Spanish only).
+- At source{d}, we have a transparent salary policy which we feel strongly about it. Although a seniority level for every candidate will be determined during the last round of on-site interviews, one can expect that for a Senior Engineer salary ranges from €60.000 to €70.000. You can find our net amounts [here](https://cincodias.elpais.com/herramientas/calculadora-sueldo-neto/) (in Spanish only).
 
 - Following the same level of transparency as with development process, all the above aspects of the work culture are documented and publicly available in our Guide at https://github.com/src-d/guide/.
 

--- a/talent/job-descriptions/senior-ds.md
+++ b/talent/job-descriptions/senior-ds.md
@@ -15,7 +15,7 @@
 - ml: MLoSC framework.
 - apollo: modular source code de-duplication research project.
 - kmcuda: lightning fast K-means and K-nearest neighbours on NVIDIA GPUs. It allows us to cluster 3 million samples, each 256 dimensions, into 1000 clusters in less than 20 minutes with the outstanding precision using two NVIDIA Titan X cards.
-- minhashcuda - lightning fast Weighted MinHash on NVIDIA GPUs. This tool allowed us to scan all +17M git repositories in 30 minutes and find 1.5M duplicates (the results were
+- minhashcuda: lightning fast Weighted MinHash on NVIDIA GPUs. This tool allowed us to scan all +17M git repositories in 30 minutes and find 1.5M duplicates (the results were
 published on data.world.
 - lapjv: Jonker-Volgenant algorithm to solve linear sum assignment problems, accelerated with Intel AVX2 instruction set. It is capable of transforming 4096 t-SNE dots into 64x64 images in 2 minutes.
 - wmd-relax: optimized Word Mover's Distance

--- a/talent/job-descriptions/senior-ds.md
+++ b/talent/job-descriptions/senior-ds.md
@@ -53,7 +53,7 @@ ROLE
 
 - At the moment, we are 20+ people from 10 different countries working closely together from our office in Madrid, Spain. We are more than happy to sponsor you a visa and guide you and your family through the whole process if you decide to come to work from our office, but you may also choose to work remotely as part of our team does working from Portugal, Estonia, Russia, and others.
 
-- At source{d}, we have a transparent salary policy. Depending on your experience, you can either join us as a Senior Engineer or a Lead. For a Senior Engineer, the salary ranges from €49.000 to €53.000. You can find our net amounts at https://cincodias.elpais.com/herramientas/calculadora-sueldo-neto/ (in Spanish only).
+- At source{d}, we have a transparent salary policy which we feel strongly about it. Although a seniority level for every candidate will be determined during the last round of on-site interviews, one can expect that for a Senior Engineer salary ranges from €49.000 to €53.000. You can find our net amounts [here](https://cincodias.elpais.com/herramientas/calculadora-sueldo-neto/) (in Spanish only).
 
 - Following the same level of transparency as with development process, all the above aspects of the work culture are documented and publicly available in our Guide at https://github.com/src-d/guide/.
 

--- a/talent/job-descriptions/senior-ds.md
+++ b/talent/job-descriptions/senior-ds.md
@@ -1,0 +1,70 @@
+- At source{d} we are building the stack for the next generation of Machine Learning powered developer tools.
+
+- We have raised over eight million USD so far, and we are currently growing our team.
+
+- Our current monetization strategy is based on deploying our stack and tooling within large tech companies.
+
+## TEAM
+
+- The Data Science team is focused on providing intelligent insights into nearly all the world's open source code. This includes typical big data analysis as well as solving sophisticated Machine Learning problems. The former is conducted on Apache Spark clusters with up to 1,000 nodes, the latter leverage extensive GPGPU acceleration on the custom hardware and Deep Learning techniques, standing on top of source{d}'s original open source projects and Tensorflow. Often, arising ML problems are unsupervised and require much research in the unusual domain of ML on source code (MLoSC).
+
+- source{d} tries to be as open in it's ongoing research as possible. If a handy developed tool can be open-sourced then it has to be. If a solved interesting problem can be disclosed, it has to be published in source{d}'s blog. If a funny dataset is compiled, it is published on data.world. Writing papers is welcomed. We talk on conferences literally every month.
+
+- To this moment, source{d}'s engineers have developed:
+- src-d/awesome-machine-learning-on-source-code - everything that we know about MLoSC.
+- ml - MLoSC framework.
+- apollo - modular source code de-duplication research project.
+- kmcuda - lightning fast K-means and K-nearest neighbours on NVIDIA GPUs. It allows us to cluster 3 million samples, each 256 dimensions, into 1000 clusters in less than 20 minutes with the outstanding precision using two NVIDIA Titan X cards.
+- minhashcuda - lightning fast Weighted MinHash on NVIDIA GPUs. This tool allowed us to scan all +17M git repositories in 30 minutes and find 1.5M duplicates (the results were
+published on data.world.
+- lapjv - Jonker-Volgenant algorithm to solve linear sum assignment problems, accelerated with Intel AVX2 instruction set. It is capable of transforming 4096 t-SNE dots into 64x64 images in 2 minutes.
+- wmd-relax - optimized Word Mover's Distance
+- hercules - Git repositories line burn down analysis command line tool built on top of source{d}'s go-git - Git client and server implementation in pure Go language.
+• sparkpickle - the tool to read PySpar RDD files without having to install Spark.
+
+### The following notable technical posts, papers and talks exist:
+- Source Code Identifier Embeddings
+- Open Source Stack for Machine Learning on Source Code
+- Analyzing GitHub, How Developers Change Programming Languages Over Time
+- GitHub Contributions Graph: Analyzing Pagerank & Proving the 6 Handshakes Theory
+- Similarity of GitHub Repositories by Source Code Identifiers
+- 397 Languages, 18,000,000 GitHub repositories, 1.2 billion files, 20 terabytes of code: Spaces or Tabs
+- Topic modeling of public repositories at scale using names in source code - paper
+- Hands on with the most starred GitHub repositories
+- Source code abstracts classification using CNN
+
+### The following datasets published:
+- Names in source code extracted from 13 000 000 GitHub repositories. Not people! 30GB
+- October 2016 GitHub repositories not marked as forks but very similar to each other
+- Readme files found in all GitHub repositories (16M, October 2016
+- ≈ 452,000,000 commits' metadata taken from 16,000,000 repositories on GitHub (Oct 2016)
+
+
+ROLE
+
+- Strong computer science and machine learning background is essential for data science team members. You will be expected to be a passionate, skillful engineer who is able to produce amazing results quickly and reliably. Coding skills are important; we are using Python 3 and Go in our research and production prototyping. Besides, we occasionally code in C++ and CUDA. MLoSC shares common ideas with Natural Language Processing, so solid NLP knowledge is also required. Deep Learning experience is highly appreciated.
+
+
+## CULTURE
+
+- source{d} is a company for developers by developers. We firmly believe in always doing what's best for the community, not necessarily companies. "For developers" is the answer to any strategic question or dilemma in the company. Always For Developers.
+
+- "By developers" is our identity. Everyone in the company is either a developer or has a developer/engineering mindset. We don't hire anyone who doesn't fit into this culture, it's the only way to make sure everyone understands developers and can always defend their interest.
+
+- At the moment, we are 20+ people from 10 different countries working closely together from our office in Madrid, Spain. We are more than happy to sponsor you a visa and guide you and your family through the whole process if you decide to come to work from our office, but you may also choose to work remotely as part of our team does working from Portugal, Estonia, Russia, and others.
+
+- At source{d}, we have a transparent salary policy. Depending on your experience, you can either join us as a Senior Engineer or a Lead. For a Senior Engineer, the salary ranges from €49.000 to €53.000. You can find our net amounts at https://cincodias.elpais.com/herramientas/calculadora-sueldo-neto/ (in Spanish only).
+
+- Following the same level of transparency as with development process, all the above aspects of the work culture are documented and publicly available in our Guide at https://github.com/src-d/guide/.
+
+## PERKS 
+
+ - EU Visa support.
+ - Open Source Days, 10% of the time you can work on any OSS project you choose.
+ - Flexible hours and the possibility of remote work.
+ - We go to conferences and other developer events ! ;)
+ - Free books. Company will buy any books that can help you be even better at your work.
+ - Spacious physical office, close to public transit and to the Retiro park.
+ - Kitchen, full of supplies from beers to fresh fruits.
+ - Monthly get-togethers, annual summer and winter Xmas parties, a retreat.
+ - Our own, open source craft beers src-d/homebrew.


### PR DESCRIPTION
@vmarkovtsev, we are in the process of reviewing and updating the job descriptions on Lever. 

The parts of Intro, Culture and Perks have already been reviewed and it’s recommended to be same as every other role for consistency. 

The “TEAM” and “ROLE” are the ones that you are responsible to update in case you think it’s necessary. 

In the other job descriptions, the "TEAM" describes the teams at source{d} and a bit of the specific one. An example is here: https://github.com/src-d/guide/pull/108 .

Feel free to make any changes you think is necessary and let me know if there is anything I can do from my side to help. Later I will apply the changes on Lever.