### PR TITLE
Implementing CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# default
+* @jorgeschnura 
+
+# sections
+developer-community/* @campoy 
+engineering/* @mcuadros 
+office/* @estherrgarcia 
+talent/* @tsolakoua
+product/* @marnovo

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # source{d} guide
 
-Welcome! The source{d} guide documentation is where you will find all information about how it's like to work here. It contains all the info you need from the moment you accept an offer to work with us onwards. The information contained here is not just about work, but also about other interesting things.
+Welcome! The source{d} guide documentation is where you will find all information relevant for sourcerers (source{d} team members) and anyone interested in who we are, what we do, and how we do it.
 
-This documentation is open to everyone, sourcerers and non-sourcerers. So feel free to suggest improvements and changes via pull requests and to ask questions via issues.
+This documentation is open to everyone, sourcerers and non-sourcerers. So please feel free to suggest improvements or ask questions via [issues](issues), or directly open a [pull request](pulls) suggesting changes or reviewing someone those of someone else.
+
+We try to put as much information here as possible, in the rare cases that a topic should be private within the company, please redirect to [src-d/company](https://github.com/src-d/company/).
 
 * General
   * Mission & Vision
@@ -13,41 +15,16 @@ This documentation is open to everyone, sourcerers and non-sourcerers. So feel f
   * [Investors, Board of Directors and Advisors](general/investors_board_advisors.md)
   * Leadership
   * Objectives & Key Results (OKRs)
-  * Communications
   * [Company Wide Meeting](general/company_wide_meeting.md)
   * [Remote Guidelines](remote/remote_guidelines.md)
   * [Tools](general/tools.md)
   * [Hardware](general/available_hardware.md)
   * Security
   * [Expenses & Travel](general/expenses_travel.md)
-* Office
-  * [Facilities & Seating Chart](office/madrid_office_seating_chart.md)
-  * [Company Events](office/company_events.md)
-  * [source{d} Open Source Beer Brewery](https://github.com/src-d/homebrew)
-  * [Books](office/books_list.md)
-* Talent
-  * [Hiring Process](talent/hiring_process.md)
-  * [Contract](talent/contract.md)
-  * [Stock Option Plan](talent/esop.md)
-  * [Flexible Holidays, Working Schedule and Remote Work](talent/flexible_holidays_working_schedule_remote_work.md)
-  * [Onboarding](talent/onboarding)
-  * ["By Developers" Training](talent/by-developers-training/README.md)
-  * Career development
-  * [One-On-One Meetings Guide](talent/one_on_one_guide.md)
-  * [Open Source Days](/talent/open_source_days.md)
-  * Offboarding
-* Engineering
-  * [Methodology](engineering/methodology.md)
-  * [Project Maintainers](engineering/maintainers.md)
-  * [Git workflow](engineering/git-flow.md)
-  * [Documentation Guide](engineering/documentation.md)
-  * [Licensing Policy](engineering/licensing.md)
-* Developer Community
-  * [Tech Talks](developer-community/tech-talks.md)
-  * [Events Guidelines](developer-community/events.md)
-  * [Events List](developer-community/events-list.md)
-  * [Engineering Blog](https://blog.sourced.tech)
-  * [Company Blog](https://medium.com/source-d)
+* [Office](office/)
+* [Talent](talent/)
+* [Engineering](engineering/)
+* [Developer Community](developer-community/)
 * Product
   * Methodology
   * [Design Guide](general/design-guide.md)

--- a/communication/README.md
+++ b/communication/README.md
@@ -1,0 +1,5 @@
+### Communication
+
+**Maintainer:** [@jorgeschnura](https://github.com/jorgeschnura)
+
+* [Slack channels](communication/slack_channels.md)

--- a/developer-community/README.md
+++ b/developer-community/README.md
@@ -1,0 +1,10 @@
+### Developer Community
+
+**Maintainer:** [@campoy](https://github.com/campoy)
+
+* [Tech Talks](tech-talks.md)
+* [Events Guidelines](events.md)
+* [Events List](events-list.md)
+* [Conferences CFP's](https://github.com/src-d/conferences/issues)
+* [Engineering Blog](https://blog.sourced.tech)
+* [Company Blog](https://medium.com/source-d)

--- a/engineering/README.md
+++ b/engineering/README.md
@@ -1,0 +1,16 @@
+### Engineering
+
+**Maintainer:** [@mcuadros](https://github.com/mcuadros)
+
+* [Methodology](methodology.md)
+  * [Language Analysis Team](methodology-language-analysis.md)
+* [Project Maintainers](maintainers.md)
+* [Git workflow](git-flow.md)
+* [Continuous Delivery](continuous-delivery.md)
+* [Documentation Guide](documentation.md)DocumeDocumentnt
+  * [Git Repo Templates](documents/)
+* [Licensing Policy](icensing.md)Document
+
+#### Other
+
+* [Python Style Guide](python-style-guide.md)

--- a/engineering/methodology.md
+++ b/engineering/methodology.md
@@ -108,15 +108,13 @@ Demo meetings
 
   + Starting at the end of the second sprint, one every other sprint.
 
-  + Every 2nd week of sprint, on Fridays after the [sprint demo](https://github.com/src-d/guide/blob/master/engineering/methodology.md#Demo).
+  + Every 2nd week of sprint, on Fridays after the [sprint demo](#Demo).
 
 ### Keeping track of things:
 
   + Publicly: a Kanban board on-line.
 
   + Per team: any way team sees fit (github issues, github projects, waffle.io...).
-
-  + [src-d/issues-general](https://github.com/src-d/issues-general) - should be used more, as place for feedback/requests (i.e website, etc)
 
   + [src-d/issues-infrastructure](https://github.com/src-d/issues-infrastructure) - issues/requests to Infrastructure team must be created here.
 

--- a/office/README.md
+++ b/office/README.md
@@ -1,0 +1,8 @@
+### Communication
+
+**Maintainer:** [@estherrgarcia](https://github.com/estherrgarcia)
+
+* [Facilities & Seating Chart](madrid_office_seating_chart.md)
+* [Company Events](company_events.md)
+* [Books](books_list.md)
+* [source{d} Open Source Beer Brewery](https://github.com/src-d/homebrew)

--- a/talent/README.md
+++ b/talent/README.md
@@ -1,0 +1,14 @@
+### Communication
+
+**Maintainer:** [@tsolakoua](https://github.com/tsolakoua)
+
+* [Hiring Process](hiring_process.md)
+* [Contracts](contract.md)
+* [Stock Option Plan](esop.md)
+* [Flexible Holidays, Working Schedule and Remote Work](flexible_holidays_working_schedule_remote_work.md)
+* [Onboarding](onboarding)
+* ["By Developers" Training](by-developers-training/README.md)
+* [One-On-One Meetings Guide](one_on_one_guide.md)
+* [Open Source Days](open_source_days.md)
+* Career development
+* Offboarding


### PR DESCRIPTION
Suggested by @dpordomingo here https://github.com/src-d/guide/issues/99 and supported by @campoy in https://github.com/src-d/guide/issues/105

This PR implements the CODEOWNERS suggestion from @dpordomingo and reorganizes the repository and its README.md accordingly. 

The rationale is:

* A maintainer per subsection gives more ownership 
* Easier to maintain

Before merging this PR, I'd like the approval @jorgeschnura since you've been the global maintainer so far. You remain the global maintainer but subsections will have owners. Feel free to make any obvious changes directly on this branch.