### PR TITLE
Add SF engineering role

### DIFF
--- a/talent/job-descriptions/applications_eng_SF.md
+++ b/talent/job-descriptions/applications_eng_SF.md
@@ -28,7 +28,7 @@ Our libraries and applications are available under the following GitHub organiza
 
 This position is for a Senior Engineer on the Applications team, based in SF or remote. 
 
-- You will be expected to have a deep understanding and previous experience in developer tooling on a large scale. 
+- You will be expected to have a deep understanding and 2+ years of previous experience in developer tooling on a large scale. 
 
 - Your main responsibilities will be prototyping and exploring the future of developer tooling by discovering new applications that could be meaningful to the developer community. 
 

--- a/talent/job-descriptions/applications_eng_SF.md
+++ b/talent/job-descriptions/applications_eng_SF.md
@@ -30,11 +30,11 @@ This position is for a Senior Engineer on the Applications team, based in SF or 
 
 - You will be expected to have a deep understanding and previous experience in developer tooling on a large scale. 
 
-- Your main responsibilities will be prototyping and explore the future of developer tooling by discovering new applications that could be meaningful for the developer community. 
+- Your main responsibilities will be prototyping and exploring the future of developer tooling by discovering new applications that could be meaningful to the developer community. 
 
-- We are looking for someone who has a decent understanding of Machine Learning, as you will deal with models built using modern ML stacks written in Python and C++ like Tensorflow, Tensorboard and CUDA.
+- We are looking for someone who has a good understanding of Machine Learning, as you will deal with models built using modern ML stacks written in Python and C++ like Tensorflow, Tensorboard and CUDA.
 
-- You will be working closely with the Developer Relations team in order to explore and identify ideas. You will have the opportunity to write blog posts and make videos about our technology, even though it's not main responsibility of the role. 
+- You will be working closely with the Developer Relations team in order to explore and identify ideas. You will have the opportunity to write blog posts and make videos about our technology, even though it's not the main responsibility of the role. 
 
 - It's important to combine your coding skills with your social skills in order to demonstrate the developer tools we build to the developer community. 
 

--- a/talent/job-descriptions/applications_eng_SF.md
+++ b/talent/job-descriptions/applications_eng_SF.md
@@ -1,0 +1,56 @@
+- At source{d} we are building the stack for the next generation of Machine Learning powered developer tools.
+
+- We have raised over eight million USD so far, and we are currently growing our team.
+
+- Our current monetization strategy is based on deploying our stack and tooling within large tech companies.
+
+## TEAM
+
+- Engineering consists of five different teams, that mimic the architecture of our product:
+
+- Applications (Scala, Go and Python and Frontend tools): Builds CLI/Web applications based on ML research.
+- Machine Learning (C++ and Python): R&D of machine learning on source code.
+- Data Retrieval (Scala and Go): Builds the technology that finds, fetches, stores and analyzes over +60M Git repositories.
+- Language Analysis (Go and another +15): Works on Babelfish, the universal code parsing server.
+- Infrastructure (Go and Python): Manages on-prem bare metal servers with Kubernetes and CoreOS.
+ 
+We really care about Open Source. Everything we develop is available for anyone to read, modify, and contribute.
+Our libraries and applications are available under the following GitHub organizations:
+
+- [bblfsh/dashboard](https://github.com/bblfsh/dashboard): a playground application for Babelfish server, turning code files into Universal Abstract Syntax Trees (UASTs). 
+- [src-d/kmcuda](https://github.com/src-d/kmcuda):  fast K-means and K-nearest neighbours on NVIDIA GPUs.  
+- [src-d/minhashcuda](https://github.com/src-d/minhashcuda):  fast Weighted MinHash on NVIDIA GPUs. It allows for fast nearly-duplicate repository detection: scan +17 git repositories in 30 minutes to find 1.5M duplicates (the results were published on data.world).  
+- [src-d/engine](https://github.com/src-d/engine):  a library for running scalable data retrieval pipelines that process any number of Git repositories for source code analysis.  
+- [src-d/hercules](https://github.com/src-d/hercules):  analysis and visualization of a Git repository history. 
+- [src-d/gemini](https://github.com/src-d/gemini): a duplicate finder for source code in git repositories.
+
+## ROLE
+
+This position is for a Senior Engineer on the Applications team, based in SF or remote. 
+
+- You will be expected to have a deep understanding and previous experience in developer tooling on a large scale. 
+
+- Your main responsibilities will be prototyping and explore the future of developer tooling by discovering new applications that could be meaningful for the developer community. 
+
+- We are looking for someone who has a decent understanding of Machine Learning, as you will deal with models built using modern ML stacks written in Python and C++ like Tensorflow, Tensorboard and CUDA.
+
+- You will be working closely with the Developer Relations team in order to explore and identify ideas. You will have the opportunity to write blog posts and make videos about our technology, even though it's not main responsibility of the role. 
+
+- It's important to combine your coding skills with your social skills in order to demonstrate the developer tools we build to the developer community. 
+
+## CULTURE
+
+- source{d} is a company for developers by developers. We firmly believe in always doing what's best for the community, not necessarily companies. "For developers" is the answer to any strategic question or dilemma in the company. Always For Developers.
+
+- "By developers" is our identity. Everyone in the company is either a developer or has a developer/engineering mindset. We don't hire anyone who doesn't fit into this culture, it's the only way to make sure everyone understands developers and can always defend their interest.
+
+- Following the same level of transparency as with development process, all the above aspects of the work culture are documented and publicly available in our Guide at https://github.com/src-d/guide/.
+
+## PERKS
+
+ - Open Source Days, 10% of the time you can work on any OSS project you choose.
+ - Flexible hours and the possibility of remote work.
+ - We go to conferences and other developer events ! ;)
+ - Free books. Company will buy any books that can help you be even better at your work.
+ - Monthly get-togethers, annual summer and winter Xmas parties, a retreat.
+ - Our own, open source craft beers https://github.com/src-d/homebrew.


### PR DESCRIPTION
This is the description of the Applications role in SF, after the requirements I received last Friday from @eiso and @campoy. 

After receiving your feedback, I will work on the senior PM that should be very similar to this one. 

I didn't add "Interaction with eventual/ potential customers" responsibility and will add it in the PM role, as I think it's more relevant and will also add some difference to the roles that look very similar. 

Tech-wise it might seem a bit broad as I didn't mention anywhere the technologies he needs to know. Please update me on that in case it's not the same with the Applications requirements we have in Madrid  role (You will be expected to have strong backend coding skills in at least one programming language and very good algorithmic skills. Scala coding skills and knowledge about Apache Spark aren't required but will be highly appreciated). 