### PR TITLE
Officially deprecate event list

### DIFF
--- a/developer-community/events-list.md
+++ b/developer-community/events-list.md
@@ -1,3 +1,5 @@
+(DEPRECATED: please follow the instructions in github.com/src-d/conferences to track new events)
+
 # Events
 
 ## January 2017

--- a/developer-community/events-list.md
+++ b/developer-community/events-list.md
@@ -1,4 +1,4 @@
-(DEPRECATED: please follow the instructions in github.com/src-d/conferences to track new events)
+(DEPRECATED: please follow the instructions in [src-d/conferences](https://github.com/src-d/conferences) to track new events)
 
 # Events
 


### PR DESCRIPTION
As suggested by @marnovo in src-d/minutes#208 (comment)


Signed-off-by: Francesc Campoy <campoy@golang.org>