### PR TITLE
engineering: add coding guides

### DIFF
--- a/engineering/README.md
+++ b/engineering/README.md
@@ -6,11 +6,11 @@
   * [Language Analysis Team](methodology-language-analysis.md)
 * [Project Maintainers](maintainers.md)
 * [Git workflow](git-flow.md)
+* [Development Conventions](conventions.md)
+  * [Go](conventions-go.md)
+  * [Python](conventions-python.md)
+  * [Scala](conventions-scala.md)
 * [Continuous Delivery](continuous-delivery.md)
 * [Documentation Guide](documentation.md)
   * [Git Repo Templates](documents/)
 * [Licensing Policy](licensing.md)
-
-#### Other
-
-* [Python Style Guide](python-style-guide.md)

--- a/engineering/conventions-go.md
+++ b/engineering/conventions-go.md
@@ -1,0 +1,65 @@
+
+# Go Development Conventions
+
+## Introduction
+
+This guide documents development conventions for Go at source{d}. Check [general conventions](conventions.md) for language-independent conventions that are also applicable for Go projects.
+
+## Supported Go Versions
+
+* Support latest two stable major versions of Go (e.g. 1.9.x and 1.10.x). Both versions should be included in Travis CI.
+  * Some of our projects may support more versions, specially when there is wide-adoption outside source{d} (e.g. [go-git](https://github.com/src-d/go-git) currently supports three).
+  * We try to support new Go versions as fast as possible. Versions to test in Travis CI include `tip` with [allowed failures](https://docs.travis-ci.com/user/customizing-the-build#Rows-that-are-Allowed-to-Fail) to help us identifying problems with next version ahead of time.
+
+## Dependency Management
+
+* If your project is an application:
+  * Use [dep](https://github.com/golang/dep) to manage dependencies.
+  * Check in the `vendor` directory into git.
+* If your project is a library:
+  * Use [gopkg.in](http://labix.org/gopkg.in) to provide versioned imports.
+
+## Build System
+
+* If your project requires fetching or building dependencies, implement that in the `dependencies` rule.
+* If binaries can be built, do so in the `packages` rule. Note that [src-d/ci](https://github.com/src-d/ci) provides that rule by default.
+
+## Testing
+
+* Use [testify](https://github.com/stretchr/testify).
+* Use [suites](https://github.com/stretchr/testify#suite-package) to share setup/teardown code among related tests. When testing multiple methods of the same struct, you generally want to start with a suite. Some cases, such as table-driven tests, are better handled with [subtests](https://blog.golang.org/subtests) though.
+
+## Executables
+
+* Put sources for your executable commands in `cmd/<command-name>/main.go`.
+* We use [go-flags](https://github.com/jessevdk/go-flags) extensively for CLI options parsing.
+
+## Error handling
+
+* Use [src-d/go-errors](https://github.com/src-d/go-errors).
+
+## Logging
+
+* Use logging in your applications.
+* Use [logrus](https://github.com/sirupsen/logrus) for logging.
+* Use [fields](https://github.com/sirupsen/logrus#fields) instead of string formatting in the log message.
+
+## Other libraries
+
+* We use protobuf extensively and [gogo](https://github.com/gogo/protobuf) is our preferred library.
+
+## Best Practices
+
+* Use `gofmt`, `goimports`, `go vet`.
+* Follow community well-established best practices: [Effective Go](https://golang.org/doc/effective_go.html) and [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments).
+* Sourcerers use additional linters such as [golint](https://github.com/golang/lint) and [megacheck](https://github.com/dominikh/go-tools/tree/master/cmd/megacheck).
+
+### Group code blocks with blank lines
+
+In order to improve readability, we use single blank lines to separate logic blocks of code inside functions.
+
+A blank line is usually added after the end of any control structure, too.
+
+### Naming
+
+* Prefer full names (e.g. `Repository`, not `Repo`).

--- a/engineering/conventions-python.md
+++ b/engineering/conventions-python.md
@@ -1,4 +1,11 @@
-# source{d} Python Style Guide
+
+# Python Development Conventions
+
+## Introduction
+
+This guide documents development conventions for Python at source{d}. Check [general conventions](conventions.md) for language-independent conventions that are also applicable for Python projects.
+
+## Code Style
 
 1. Contributing to existing projects - do not change the style.
 2. [PEP8](https://www.python.org/dev/peps/pep-0008/) with 99 char line length limit

--- a/engineering/conventions-scala.md
+++ b/engineering/conventions-scala.md
@@ -1,0 +1,44 @@
+
+# Scala Development Conventions
+
+## Introduction
+
+This guide documents development conventions for Scala at source{d}. Check [general conventions](conventions.md) for language-independent conventions that are also applicable for Scala projects.
+
+## Supported Scala and JVM Versions
+
+Given that most of our Scala projects are related to [Apache Spark](https://spark.apache.org/), our compatibility policy is closely related to it.
+
+* Actively support Java 8. Java 9 on a best-effort basis.
+* Support Scala 2.11.
+
+## Build System
+
+* Use [sbt](https://www.scala-sbt.org/).
+* Include an sbt wrapper in the top-level directory (e.g. [paulp/sbt-extras](https://github.com/paulp/sbt-extras)).
+* Use [sbt-assembly](https://github.com/sbt/sbt-assembly) if fat jars are required.
+* You can use [coursier](https://github.com/coursier/coursier) for faster dependency downloading.
+* Integrate code coverage and scalastyle check in your sbt build files.
+
+## Publishing
+
+* Artifacts should be published to Maven Central under the `tech.sourced` organization.
+
+## Testing
+
+* Use [scalatest](http://www.scalatest.org/).
+* Prefer [FlatSpec](http://www.scalatest.org/user_guide/selecting_a_style) style.
+* Add the `Spec` suffix to test file names.
+
+## Logging
+
+* If working with Spark, you might use `org.apache.spark.internal.Logging`.
+* [slf4j](https://www.slf4j.org/) otherwise.
+
+## Code Style
+
+We do not have fully standarized style for our Scala projects. However, they all stay close to [default scalastyle config](http://www.scalastyle.org/scalastyle_config.xml) with either 100 or 120 maximum line length. You may want to use [scalafmt](http://scalameta.org/scalafmt/) for automatic formatting too.
+
+## Best Practices
+
+* [Effective Scala](http://twitter.github.io/effectivescala/) is a good summary of best practices you should follow.

--- a/engineering/conventions.md
+++ b/engineering/conventions.md
@@ -1,0 +1,48 @@
+
+# Development Conventions
+
+## Introduction
+
+This guide documents development conventions that are language-independent, so they are applicable to every source{d} project.
+
+We have additional conventions for each language:
+
+* [Go](conventions-go.md)
+* [Python](conventions-python.md)
+* [Scala](conventions-scala.md)
+
+## Versioning
+
+* Use [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+  * Note that backwards compatibility rules [do not apply to `0.y.z` versions](https://semver.org/#spec-item-4).
+* When creating version tags in git, use the `v` prefix (e.g. `v0.5.0`). See our [git guide](git-flow.md) for more information.
+
+## Build System
+
+* All projects have a `Makefile` at the top-level directory.
+* Makefile should be compatible with `[GNU make](https://www.gnu.org/software/make/manual/make.html)`.
+* [src-d/ci](https://github.com/src-d/ci) should be used in these makefiles to provide integration with our continuous integration systems.
+
+## Continuous Integration
+
+* All open source projects should be integrated with [Travis CI](https://travis-ci.org/) for continuous integration. Check [src-d/ci examples](https://github.com/src-d/ci/tree/master/examples).
+* Drone is used for continuous delivery. If you are working on a web application, read the [continuous delivery guide](continuous-delivery.md) too.
+
+## Publishing
+
+* Binaries should be attached to GitHub Releases. src-d/ci will do this automatically.
+
+## Docker
+
+* Applications should be packaged with Docker.
+* Include `Dockerfile` in the top-level directory of the project.
+* Use latest [alpine](https://hub.docker.com/_/alpine/) or [busybox](https://hub.docker.com/_/busybox/) whenever it is possible. Use latest [debian](https://hub.docker.com/_/debian/) stable-slim otherwise.
+* If needed to reduce image size, use [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/).
+
+## Others
+
+Refer to the [licensing](licensing.md), [maintainers](maintainers.md) and [documentation](documentation.md) guides for other important information you should know when creating new projects.
+
+## Development Environments
+
+Each sourcerer has his own preferences on editors and IDEs. But if you do not know what to use, [Visual Studio Code](https://code.visualstudio.com/) is a popular choice for Go and Python, and [IntelliJ IDEA](https://www.jetbrains.com/idea/) is the most used for Java and Scala.

--- a/engineering/git-flow.md
+++ b/engineering/git-flow.md
@@ -43,7 +43,7 @@ master. Using `rebase -i` command is an easy task.
 # How to create a new version (maintainers only)
 
 ## 1. Create a tag
-In most of the cases we create a new tag from a master commit using [semantic versioning](http://semver.org/) with the "v" prefix: `v1.0.0`, `v1.0.3`, `v2.0.0-rc1`, and so on.
+In most of the cases we create a new tag from a master commit using [semantic versioning](http://semver.org/) with the `v` prefix: `v1.0.0`, `v1.0.3`, `v2.0.0-rc1`, and so on.
 
 If we want to create a new major version that breaks the public API, we can create a tag from a specific branch.
 


### PR DESCRIPTION
Added guides for our engineering conventions and best practices. One general guide, and one per-language.

These are drafts meant to start a discussion. The initial intent is to document best practices that are already accepted and completely or partially implemented in our projects, not to introduce major changes.

Fixes #109 