### PR TITLE
engineering: change cmd for cli in go conventions

### DIFF
--- a/engineering/conventions-go.md
+++ b/engineering/conventions-go.md
@@ -31,7 +31,7 @@ This guide documents development conventions for Go at source{d}. Check [general
 
 ## Executables
 
-* Put sources for your executable commands in `cmd/<command-name>/main.go`.
+* Put sources for your executable commands in `cli/<command-name>/main.go`.
 * We use [go-flags](https://github.com/jessevdk/go-flags) extensively for CLI options parsing.
 
 ## Error handling


### PR DESCRIPTION
This reflects our current convention, already applied to many projects.

As discussed previously, this actually reflects our current convention and there was no consensus so far on changing it:
https://github.com/src-d/guide/pull/196#discussion_r182983411