### PR TITLE
engineering: use CODEOWNERS

### DIFF
--- a/engineering/maintainers.md
+++ b/engineering/maintainers.md
@@ -2,8 +2,10 @@
 
 ## General Guidelines
 
-* Every GitHub repository must have an assigned maintainer.
-* Maintainer is specified in a MAINTAINERS file in the top level directory as follows: `Full Name <email> (@github_handle)`
+* Every GitHub repository must have, at least, one assigned maintainer.
+* Maintainers are specified in a [CODEOWNERS](https://help.github.com/articles/about-codeowners/).
+  * A global maintainer is required and it should be an individual, not a team.
+  * It is possible to assign other maintainers for specific subdirectories ([example](https://github.com/src-d/guide/blob/master/CODEOWNERS)).
 * Maintainers are in charge of:
   * Release Management: tagging, release notes, deciding on versioning, etc.
   * Code Review pull requests.
@@ -14,10 +16,10 @@
 
 * A maintainer should review every PR but can ask for additional reviewers as needed (e.g. someone else is more knowledgeable about a change or has a say as stakeholder) or completely delegate the review.
 * In order to request a code review, the maintainer can [add reviewers](https://help.github.com/articles/requesting-a-pull-request-review/) in GitHub UI
-* Non-maintainers at source{d} are not expected to do code review on PRs they are not asked to as a general practice.  However, they are allowed to at their discretion if they think it's appropriate on a specific case.
+* Non-maintainers at source{d} are not expected to do code review on PRs they are not asked to as a general practice. However, they are allowed to at their discretion if they think it's appropriate on a specific case.
 * Desirable deadline for each code review is 1 working day.
 * If there is a disagreement among the PR author and multiple reviewers and consensus cannot be reached or [it's not worth to reach](http://bikeshed.org/) the maintainer has the final word.
-* A maintainer can merge his own PRs without code review, but it is encouraged to ask for a review  Merging without review, if done, should be reserved to fixing typos or minor maintenance tasks.
+* A maintainer can merge his own PRs without code review, but it is encouraged to ask for a review. Merging without review, if done, should be reserved to fixing typos or minor maintenance tasks.
 
 ## Issues
 


### PR DESCRIPTION
This is a proposal to migrate from MAINTAINERS files to [CODEOWNERS](https://help.github.com/articles/about-codeowners/). This has some advantages such as a standard syntax to assign different maintainers to subdirectories, and it is integrated with GitHub.

Note that we created the MAINTAINERS file just a week before CODEOWNERS was released by GitHub (if I recall correctly). Changing this has been discussed informally a few times, but we never got to actually propose the change.

Changes are:

* Use CODEOWNERS instead of MAINTAINERS.

* Reflect the fact that there can be multiple maintainers. That is already the case for src-d/go-git and src-d/guide.

Signed-off-by: Santiago M. Mola <santi@mola.io>