### PR TITLE
engineering: add configuration guidelines

### DIFF
--- a/engineering/conventions-go.md
+++ b/engineering/conventions-go.md
@@ -70,3 +70,8 @@ A blank line is usually added after the end of any control structure, too.
 * Put sources for your executable commands in `cmd/<command-name>/`, with the `main` function in `cmd/<command-name>/main.go`.
 * We use [go-flags](https://github.com/jessevdk/go-flags) extensively for CLI options parsing.
 * Implement commands in a subpackage ([example](https://github.com/src-d/gitbase/blob/master/cmd/gitbase/command/server.go)).
+
+## Configuration
+
+* Use environment variables for configuration.
+* You can use the [envconfig](https://github.com/kelseyhightower/envconfig) package to parse the environment into a configuration struct.

--- a/engineering/conventions-scala.md
+++ b/engineering/conventions-scala.md
@@ -47,3 +47,7 @@ We do not have fully standarized style for our Scala projects. However, they all
 
 * Most of our applications are in the form of Spark jobs meant to be used with `spark-submit`.
 * For standalone CLI, you can check [scopt](https://github.com/scopt/scopt) which we have used in some projects and is a good fit.
+
+## Configuration
+
+* If you are creating a Spark application, use environment variables for configuration that might change on the workers (e.g. URI of some backing service that is co-located with workers) and Spark configuration for settings that need to be consistent across all workers for a given job.

--- a/engineering/conventions.md
+++ b/engineering/conventions.md
@@ -9,6 +9,7 @@
 * [Others](#others)
 * [Development Environments](#development-environments)
 * [CLI](#cli)
+* [Configuration](#configuration)
 
 ## Introduction
 
@@ -71,3 +72,9 @@ Your application will expose one or more binaries with a CLI.
 
 We prefer [GNU-style command line options](http://www.catb.org/esr/writings/taoup/html/ch10s05.html).
 That is, double dash for long options and single dash for short options (single letter). Include `--help` and `--version`. As a general rule, define always long flags, and then optionally short flags for tools that are often used interactively. When defining flags it is worth to consider matching behavior of widely used flags. For example, if `--all` is present, `-a` should be its shorthand. `--quiet` as a default instead of `--silent`. `--file/-f` for a file argument, `--output/-o` for output path, etc.
+
+## Configuration
+
+Your application should be [configured](https://12factor.net/config) using environment variables. External services (e.g. databases) URLs, storage paths, [ports to bind](https://12factor.net/port-binding) and logging format all belong to configuration.
+
+Prefer the usage of URI to describe [https://12factor.net/backing-services](backing services). For example, prefer `DATABASE=mysql://host:port/db` or `BROKER=amqp://user:pass@broker:port` over three or more different settings.


### PR DESCRIPTION
We use environment variables for configuration whenever possible.
There are some exceptions when using Spark.

Signed-off-by: Santiago M. Mola <santi@mola.io>