### PR TITLE
Remove alias to override ''commit" command

### DIFF
--- a/developer-community/fix-DCO.md
+++ b/developer-community/fix-DCO.md
@@ -117,7 +117,6 @@ You can add the following lines (or as you see suit) to your `~/.gitconfig` file
 
 ```bash
 [alias]
-  commit = commit -s
   cmsg = commit -s -m
   camend = commit -s --amend
 ```


### PR DESCRIPTION
It seems that it's not possible to override git commands https://stackoverflow.com/a/3538791/3035683