### PR TITLE
talent: add table with precalculated stock options

### DIFF
--- a/talent/esop.md
+++ b/talent/esop.md
@@ -69,6 +69,38 @@ Senior | 0.07
 Normal | 0.02
 Junior | 0.00
 
+
+Here is a table with the resulting number of options for each position on Series A stage.
+
+Team | Role | # Options
+---- | ---- | ---------
+Data Science | VP | 98
+Data Science | Lead | 49
+Data Science | Senior | 24
+Data Science | Normal | 12
+Data Science | Junior | 7
+Developer Community | VP | 98
+Developer Community | Lead | 49
+Developer Community | Senior | 24
+Developer Community | Normal | 12
+Developer Community | Junior | 7
+Engineering | VP | 96
+Engineering | Lead | 48
+Engineering | Senior | 23
+Engineering | Normal | 11
+Engineering | Junior | 6
+Product | VP | 96
+Product | Lead | 48
+Product | Senior | 23
+Product | Normal | 11
+Product | Junior | 6
+Operations | VP | 93
+Operations | Lead | 45
+Operations | Senior | 20
+Operations | Normal | 8
+Operations | Junior | 3
+
+
 ### Award letter
 When you start working with us you will receive an award letter which grants you the options that are ruled by our Stock Option Plan. You can find a template of it here.
 


### PR DESCRIPTION
fixes #252 

Generated with script:

```python
#!/usr/bin/env python

teams=[
        ('Data Science', 0.12),
        ('Developer Community', 0.12),
        ('Engineering', 0.1),
        ('Product', 0.1),
        ('Operations', 0.05)
]

stages=[
        ('Seed', 2.0),
        ('Series A', 4.0)
]

roles=[
        ('VP', 0.37),
        ('Lead', 0.17),
        ('Senior', 0.07),
        ('Normal', 0.02),
        ('Junior', 0.00)
]

total = 24394

def get_options(team, stage, role, total):
        return round((team/stage+role)/100*total)

stage_title = 'Series A'
stage_val = dict(stages)[stage_title]
for team_title, team_val in teams:
        for role_title, role_val in roles:
                options = get_options(team_val, stage_val, role_val, total)
                print('%s | %s | %d' % (team_title, role_title, options))
```