### PR TITLE
Skipping sign-off for organization members

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false


### PR DESCRIPTION
Now everyone at source{d} needs to add something like 
`Signed-off-by: Konstantin Slavnov <kslavnov@gmail.com>`
to the end of the commit message with `-s` option. 

This PR allows you to use `-S` instead to sign your commit with GPG key.
In case you did both: `git commit -s -S` now you can do only `git commit -S` and DCO check will pass. :tada: