### PR TITLE
Fixed typos and errors in developer community documentation

### DIFF
--- a/developer-community/events.md
+++ b/developer-community/events.md
@@ -2,12 +2,12 @@
 
 ## source{d} tech talks
 
-Our tech talks are one-day conferences held in Madrid at our offices, or elsewhere, where we invite up to 7-8 speakers to talk to us about a very advanced topic related with Infratsructure, Machine Learning, Frontend & more (suggestions are always more than welcome)!
+Our tech talks are one-day conferences held in Madrid at our offices, or elsewhere, where we invite up to 7-8 speakers to talk to us about a very advanced topic related with Infrastructure, Machine Learning, Frontend & more (suggestions are always more than welcome)!
 You can check all past events [here](http://talks.sourced.tech/) and all talks, as we record everything.
 
-When we organise such events, we expect the team which is closer to the topic of the event to closely help organising it. That means that for Frontend, for example, the entire platform team is responsible for choosing and inviting the speakers, approving their talks and hosting the event on its actual day (exceptions will exist of course, but this would be the ideal case).
+When we organize such events, we expect the team which is closer to the topic of the event to closely help in organizing it. That means that for Frontend, for example, the entire platform team is responsible for choosing and inviting the speakers, approving their talks and hosting the event on its actual day (exceptions will exist of course, but this would be the ideal case).
 
-The Community team will however support with all the speakers logistics, the venue, F&B, promotion materials, sponsors, communication and social media, etc.
+The Community team will however support all the speakers logistics, the venue, F&B, promotion materials, sponsors, communication and social media, etc.
 
 These events usually count around 100 attendees.
 
@@ -16,16 +16,16 @@ These events usually count around 100 attendees.
 
 Thanks to Maximo, we host the [GoMAd](https://www.meetup.com/es-ES/go-mad/) meetup on a monthly basis here at the office!
 
-On a less frequent basis, we host any meetup that asks us to - if you know anyone looking for a venue for a <75 people event feel free to suggest the back of our office. Besides, depending on the occasion, we'd be happy to sponsor drinks and pizzas/snakcs for them too!
+On a less frequent basis, we host any meetup that asks us to - if you know anyone looking for a venue for a <75 people event feel free to suggest the back of our office. Besides, depending on the occasion, we'd be happy to sponsor drinks and pizzas/snacks for them too!
 
 
 ## Beer Payback's
 
 As we try to aim for consistency, we are calling any conference side events 'beer payback'. It's not the best name, and suggestions, again, are welcome, but it's what we have at the moment. 
 
-Beer payback's are usually events that we organise abroad, next to conferences that the team is attending and which crowd would be great to engage closely with. We've done so at:
+Beer paybacks are usually events that we organize abroad, next to conferences that the team is attending and whose crowd would be great to engage closely with. We've done so at:
 - FOSDEM, Brussels
 - MSR, Buenos Aires
 
 
-### Besides the above three types of events we help organise, we're always on the lookout for CFP to submit and get anyone from the team speaking at third-parties events that could be interesting to reach and attend. This is strongly encouraged from anyone in the team and something that we cover expenses for (if said conference doesn't already).
+### Besides the above three types of events we help organize, we're always on the lookout for CFP to submit and get anyone from the team speaking at third-party events that could be interesting to reach out to and attend. This is strongly encouraged from anyone in the team and something that we cover expenses for (if said conference doesn't already).

--- a/developer-community/fix-DCO.md
+++ b/developer-community/fix-DCO.md
@@ -1,6 +1,6 @@
 # DCO is missing
 
-If you are reading this, then you want to contribute to one of the source{d}'s projects.
+If you are reading this, then you want to contribute to one of source{d}'s projects.
 That's awesome and we're glad you're here 👍.
 However, this also means that you probably have not added the "signed-off-by" signature to one or more of your commits in the pull request.
 
@@ -10,10 +10,10 @@ You may now have a fair question: why does source{d} enforce the DCO? There are 
 
   1. By signing off the contribution, you are certifying it is either your intellectual property or a valid contribution given its respective open source license origin.
   2. It follows that your contribution is, by default if valid, considered your intellectual property in countries such the United States.
-  So you could ask the project maintainer to remove one (or more) of your contributions in the future.
-  This may get very complicated as the project grows larger and well-known: imagine rewriting the Git history for everybody!
+  Thus you could ask the project maintainer to remove one (or more) of your contributions in the future.
+  This may get very complicated as the project grows larger and becomes more well-known: imagine rewriting the Git history for everybody!
 
-Thus, the DCO works as a sort of an insurance against such cases.
+Thus, the DCO works as a sort of insurance against such cases.
 
 This manual should help you to add the required `Signed-off-by: Your Name <name@email.com>` to your commits in the pull request.
 
@@ -76,7 +76,7 @@ git push -f origin <your branch here, probably "master">
 
 ### Fix Option #4: (Almost) Avoid Git
 
-Git is sometimes frustrating, and you may want to keep distance from it sometimes, for safety.
+Git is sometimes frustrating, and you may want to keep distance from it sometimes for safety.
 For now:
 
   1. Copy the modified files to a backup directory;
@@ -109,7 +109,7 @@ grep -qs "^${SIGNATURE}" "$1" || echo "\n${SIGNATURE}" >> "$1"
 
 You need to do this for each repository independently.
 
-If you want to create this hook **automatically** on every new git repositories you will create from now on (using `git init`, `git clone`...) you can use `git-templates`; to do so, just save the script described above into (duplicate files):
+If you want to create this hook **automatically** on every new git repository you will create from now on (using `git init`, `git clone`...) you can use `git-templates`; to do so, just save the script described above into (duplicate files):
 - `~/.git-templates/hooks/prepare-commit-msg`
 - `~/.git-templates/hooks/commit-msg`
 
@@ -123,7 +123,7 @@ git config --global init.templatedir ~/.git-templates
 
 ### Sign-off Option #3: Git Aliases
 
-Git aliases are like "shortcuts" to more extense commands and flags.
+Git aliases are like "shortcuts" to more extensive commands and flags.
 
 You can add the following lines (or as you see suit) to your `~/.gitconfig` file:
 

--- a/developer-community/tech-talks.md
+++ b/developer-community/tech-talks.md
@@ -44,7 +44,7 @@ To avoid any last minute schedule changes due to potential cancellations, we sho
 
 From each speaker, we'll need to collect a __Bio, Picture, Title & Abstract__ in order to build the website. 
 
-If the speaker is not based at where the talk takes place, we'll need to start organizing his/her trip asap so that we avoid expensive last minute tickets & hotels.
+If the speaker is not based where the talk takes place, we'll need to start organizing his/her trip asap so that we avoid expensive last minute tickets & hotels.
 
 Email copy:
 

--- a/developer-community/tech-talks.md
+++ b/developer-community/tech-talks.md
@@ -2,9 +2,9 @@
 
 Our tech talks host great speakers in an informal setting every ~3 months. Each series of talks will cover a different topic targeted to an experienced technical audience. Speakers will be invited both from Spain and abroad.
 
-Each edition is usually more related with one specific team and this is the group of people responsible for ensuring that the event meets the expectations of the targeted audience. This means that, for intance, the Frontend edition is co-organised by the Platform team. The teams are responsible for choosing and reaching out (only until first response) to the speakers but also helping them choose the topics they'll speak about and organise the schedule in a coherent way. They are also in charge of giving a long/lightning talk themselves and, if they want, present the whole event :)
+Each edition is usually more related to one specific team, which is the group of people responsible for ensuring that the event meets the expectations of the targeted audience. This means that, for instance, the Frontend edition is co-organized by the Platform team. The teams are responsible for choosing and reaching out (only until first response) to the speakers but also helping them choose the topics they'll speak about and organize the schedule in a coherent way. They are also in charge of giving a long/lightning talk themselves and, if they want, present the whole event :)
 
-Besides the team assigned to the specific edition, anyone who wants to volunteer and will have the time, close to the event especially, to do so, is, of course, more than welcome!
+Besides the team assigned to the specific edition, anyone who wants to volunteer and will have the time, especially close to the event, to do so, is, of course, more than welcome!
 
 
 # Speakers
@@ -12,7 +12,7 @@ Besides the team assigned to the specific edition, anyone who wants to volunteer
 
 Ideally, we should start contacting speakers __3 months__ prior to the event.
 
-Our tech talks involve a total of __5 long talks__ and __2 lightning__. Someone from our team should always give either one Lightning or a Long talk. Hence, we should make an initial list of _6 people to contact_. If no reply, _follow-up after 3-5 days_ until you get an answer (up to 4 emails sent in total). 
+Our tech talks involve a total of __5 long talks__ and __2 lightning__. Someone from our team should always give either one Lightning or a Long talk. Hence, we should make an initial list of _6 people to contact_. If there is no reply, _follow-up after 3-5 days_ until you get an answer (up to 4 emails sent in total). 
 
 Email copy:
 
@@ -20,7 +20,7 @@ Email copy:
 >
 > My name is John Eod, we met last year at techFest.
 >
-> I am working at source{d} and we are organising a one-day conference focused on infra/ML/front-end technologies. Please, feel free to take a look at our past edition, around infra/ML/front-end, on our website and check out the respective videos.
+> I am working at source{d} and we are organizing a one-day conference focused on infra/ML/front-end technologies. Please, feel free to take a look at our past edition, around infra/ML/front-end, on our website and check out the respective videos.
 >
 > We saw your talk ******** and this is exactly what we are looking for: an advanced technical talk that, while focusing on a particular framework, is useful for the community as a whole.
 >
@@ -38,13 +38,13 @@ Email copy:
 
 When inviting speakers, please check how they present, speak (in English in our case), etc. You can usually find material online. If not, please schedule a short call, in English, with them so as to check all this before the actual invitation.
 
-To avoid any last minute schedule changes due to potential cancellations, we should always ask someone from our team to have a long talk prepared. This way, if someone doesn't make it, there's an easy replacement available. If all else fails, please make sure to email all attendees as soon as you know this (please remember to organise **visa** - if applicable - for this person beforehand to make sure he/she can travel if needed).
+To avoid any last minute schedule changes due to potential cancellations, we should always ask someone from our team to have a long talk prepared. This way, if someone doesn't make it, there's an easy replacement available. If all else fails, please make sure to email all attendees as soon as you know this (please remember to organize a **visa** - if applicable - for this person beforehand to make sure he/she can travel if needed).
 
 ## Information & Logistics
 
 From each speaker, we'll need to collect a __Bio, Picture, Title & Abstract__ in order to build the website. 
 
-If the speaker is not based where the talk takes place, we'll need to start organising his/her trip asap so that we avoid expensive last minute tickets & hotels.
+If the speaker is not based at where the talk takes place, we'll need to start organizing his/her trip asap so that we avoid expensive last minute tickets & hotels.
 
 Email copy:
 
@@ -54,7 +54,7 @@ Email copy:
 > 
 > As John mentioned, the event will be held on Saturday, MONTH DAY and all talks will cover quite advanced topics so hopefully it will be insightful for everyone, both attendees and speakers together.
 > 
-> The event's schedule is not completely finalised but we will be sharing more details with you soon - general idea is to start with the first talk at 10am and finish them around 5.30pm. There will be breakfast, lunch and snacks throughout the day as well as a lot of beer and drinks to ensure a great day.
+> The event's schedule is not completely finalized but we will be sharing more details with you soon - general idea is to start with the first talk at 10am and finish them around 5.30pm. There will be breakfast, lunch and snacks throughout the day as well as a lot of beer and drinks to ensure a great day.
 > 
 > Regarding the logistics, we will invite you over to Madrid/Moscow/World for the weekend and expect you at our offices on Saturday.
 > 
@@ -123,7 +123,7 @@ Email copy:
 # Setup
 ## Website
 
-Please follow the README on our [Talks repo](https://github.com/src-d/talks) or ask [@serabe](https://github.com/serabe) for a little hand :) 
+Please follow the README on our [Talks repo](https://github.com/src-d/talks) or ask [@serabe](https://github.com/serabe) for a little helping hand :) 
 
 To easily resize the HEADER pictures, use this handy set of commands:
 ```
@@ -169,7 +169,7 @@ Details for the back office:
 
 Our Meetup.com account details are secretly held by Máximo :)
 
-Each new event, simply duplicate a previous one from our [tech talks group](https://www.meetup.com/es-ES/srcd-tech-talks/). Remember to set the registration as available till the following 5min so that by the time people access it, they can no longer register. This is important as to ensure that everyone gets a ticket on Eventbrite and there are no issues on the day of the event.
+For each new event, simply duplicate a previous one from our [tech talks group](https://www.meetup.com/es-ES/srcd-tech-talks/). Remember to set the registration as available till the following 5min so that by the time people access it, they can no longer register. This is important as to ensure that everyone gets a ticket on Eventbrite and there are no issues on the day of the event.
 
 #### Twitter
 • Talks Announcement (after website is ready - speakers list might not be complete)
@@ -203,10 +203,10 @@ When the event is outside of Madrid, it's done on a case by case basis but we sh
 
 ## Printing Material
 #### Badges/Agenda
-Both Maximo & Esther have the details of the printing company. These need to be sent Thursday latest and they'll deliver them on the next day. Marcelo, or whoever joins as a Designer, will need to get all the specs at the beginning of the week but will know what to send to the printing.
+Both Maximo & Esther have the details of the printing company. These need to be sent Thursday at the latest and they'll deliver them on the next day. Marcelo, or whoever joins as a Designer, will need to get all the specs at the beginning of the week but will know what to send to the printing.
 
 #### Stickers
-We order our stickers, and any other we print, from StickerMule. The more you order (both in terms of quantity of a single design and in terms of numbers of different design) the cheapest it is, of course. So ideally, let Esther know about this in advance so we can pack that order together with any other :)
+We order our stickers, and any other we print, from StickerMule. The more you order (both in terms of quantity of a single design and in terms of numbers of different design) the cheaper it is, of course. So ideally, let Esther know about this in advance so we can pack that order together with any other :)
 
 Note that StickerMule takes around 2 weeks to ship these from the US.
 
@@ -217,14 +217,14 @@ When the event is at the office, food works as follows:
 • Lunch: Pizzas (Allo Pizza) + Salads & other (DO EAT) + Ice Cream & Fruit (Tu Despensa)
 • Beers: Selection of Spanish cold meats & cheese (Esther's Secret)
 
-When the event is outside of Madrid, it's on a case by case basis, ideally the venue takes care of it or helps organising it.
+When the event is outside of Madrid, it's on a case by case basis. Ideally the venue takes care of it or helps organizing it.
 
 ## Recordings
 When the event is at the office, we usually ask Origen Producciones to take care of it. They know how we want it and you just need to make sure they are free by emailing them (please ask Esther for the details). Until the end of the event you should also send them the pack-shots for each video cover. Example [here](https://drive.google.com/open?id=0B1AhN7PuQbtKdUFGejlaTkRzNlk) and [here](https://drive.google.com/file/d/0B9mze_Z8OL2fMl9rbDdhdGdIZFE/view). 
 
-When the event is outside of Madrid, it's on a case by case basis, ideally the venue takes care of it or helps organising it.
+When the event is outside of Madrid, it's on a case by case basis. Ideally the venue takes care of it or helps organizing it.
 
-In both cases, they should be sending you the videos ready by Friday so that we have them all uploaded latest 10 days after the event.
+In both cases, they should be sending you the ready videos by Friday so that we have them all uploaded 10 days after the event at the latest.
 
 ## Speakers Dinner
 We usually invite all the speakers for dinner after the event wherever it is held (usually typical/traditional food from the hosting city/country). Past editions were as follows:
@@ -233,7 +233,7 @@ We usually invite all the speakers for dinner after the event wherever it is hel
 • Frontend: La Castela
 
 ## Cleaning
-Esther usually takes care of warning our cleaning person that they should come an extra day (on Friday) to clean everything. They already comes every Sunday so that one is taken care of.
+Esther usually takes care of warning our cleaning person that they should come an extra day (on Friday) to clean everything. They already come every Sunday so that one is taken care of.
 
 ## Welcome Talk & Event Hosting
 Our Welcome Talk and all speakers' introductions are done by someone from the team. This person should prepare their talk and include (at least): 1. Brief company description and a more in depth one of anything we're doing that is related with the topic of the talks; 2. Why we do these talks; 3. Schedule for the day, food and drinks, bathrooms (anything useful to know).
@@ -244,12 +244,12 @@ Always stick to it. No matter what. Don't start late nor early.
 
 # Post-event
 ## Survey
-We use Typeform for all things survey and, again, Esther has the secret logins if you need them. Simply duplicate a previous ones, edit names of talks & speakers and anything else you judge necessary and send it no later than Monday at lunch. You should send it to the actual attendees (based on anyone checked in from Eventbrite) and bcc them all in one plain-text Gmail thread (no need for cool designs here). You will later use this thread to tell everyone that videos have been published and can be found at link x.
+We use Typeform for all things survey and, again, Esther has the secret logins if you need them. Simply duplicate a previous one, edit names of talks & speakers and anything else you judge necessary and send it no later than Monday at lunch. You should send it to the actual attendees (based on anyone checked in from Eventbrite) and bcc them all in one plain-text Gmail thread (no need for cool designs here). You will later use this thread to tell everyone that videos have been published and can be found at link x.
 
 ## Metrics
 We keep everything tech talks related in our [Dashboard Excel](https://docs.google.com/a/sourced.tech/spreadsheets/d/1RwXVCFkzHvrLD15GPP9HFGzSPVQ4NbwZo7BNLqaDHoA/edit?usp=sharing). 
 
-Everything you do/try/test/dream about, you should track. If you're not feeling too creative, make sure to at least track everything that allows you to reproduce the Sheets 'Summary' which include: Attendees, Budget (everything), Twitter, Survey, Blog Post.
+Everything you do/try/test/dream about, you should track. If you're not feeling too creative, make sure to at least track everything that allows you to reproduce the Sheets 'Summary' which includes: Attendees, Budget (everything), Twitter, Survey, Blog Post.
 
 ## Videos
 Videos should be online and ready no longer than 10 days after the event. We/Máximo publish/es them on Youtube. Descriptions should include the slides of the presentations given that you already had asked the speakers for. Attendees should be notified but also anyone who didn't attend or was on the waiting list.


### PR DESCRIPTION
Corrected some errors in spelling and word usage in documentation for developer community guide in order to improve overall readability for use by potential developers and community members.

Signed-off-by: michizhou <myz227@nyu.edu>