### PR TITLE
use verbatim license texts

### DIFF
--- a/engineering/documents/apache/LICENSE
+++ b/engineering/documents/apache/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -178,7 +179,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Sourced Technologies, S.L.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/engineering/documents/cc-by-sa/LICENSE
+++ b/engineering/documents/cc-by-sa/LICENSE
@@ -48,7 +48,7 @@ exhaustive, and do not form part of our licenses.
      rights in the material. A licensor may make special requests,
      such as asking that all changes be marked or described.
      Although not required by our licenses, you are encouraged to
-     respect those requests where reasonable. More_considerations
+     respect those requests where reasonable. More considerations
      for the public: 
 	wiki.creativecommons.org/Considerations_for_licensees
 
@@ -425,3 +425,4 @@ the avoidance of doubt, this paragraph does not form part of the
 public licenses.
 
 Creative Commons may be contacted at creativecommons.org.
+

--- a/engineering/documents/gpl/LICENSE
+++ b/engineering/documents/gpl/LICENSE
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -645,14 +645,14 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    <program>  Copyright (C) 2017 Sourced Technologies, S.L.
+    <program>  Copyright (C) <year>  <name of author>
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/licenses/why-not-lgpl.html>.


### PR DESCRIPTION
We are adding copyright holder name and year to the licenses text.
But instead of adding a copyright notice, we were just editing
appendixes with instructions about adding the notice, not the notice
itself. This is not valid.

Copyright notice is usually added to source code file headers in comments,
to README or to a NOTICE file.

See some examples of applying these licenses:

- Apache Foundation uses the verbatim text (without replacing anything), then
  they add copyright headers to files, see:
  https://github.com/apache/spark
  https://github.com/apache/httpd

- Android uses a custom NOTICE file, where they add their copyright notice,
  and then they add Apache License 2.0 terms and conditions without the appendix, see:
  https://android.googlesource.com/platform/dalvik/+/froyo/NOTICE
  https://android.googlesource.com/platform/dalvik/+/master/NOTICE

Since hacktoberfest started, we got *a lot* of pull requests changing from verbatim licenses to these versions, or updating the year. I've closed most of them since they're pointless, but it would be better if we sort this out in the guide to avoid future confusion.