### PR TITLE
Add 15-inch MacBook Pro to Available Hardware.

### DIFF
--- a/general/available_hardware.md
+++ b/general/available_hardware.md
@@ -10,6 +10,16 @@
 - Accessory Kit
 - Backlit Keyboard (English) & User's Guide
 
+## Apple 15-inch MacBook Pro - Space Gray
+- 2.2GHz 6-core Intel Core i7 processor, Turbo Boost up to 4.1GHz
+- 16GB 2400MHz DDR4 memory
+- 256GB SSD
+- Radeon Pro 555X with 4GB of GDDR5 memory and AGS
+- Intel UHD Graphics 630
+- Four Thunderbolt 3 (USB-C) ports
+- Force Touch trackpad
+- Backlit Keyboard (English), Touch Bar
+
 ## Dell XPS 13 Developer Edition
 - 8th Generation Intel(R) Core(TM) i7-8550U Processor
 - Ubuntu Linux 16.04


### PR DESCRIPTION
Specs from https://www.apple.com/macbook-pro/specs.

I tried to choose as similar a configuration to the 13-inch model as possible,
given the model differences. In some places I chose "equal" rather than "max",
for example 16GiB of RAM, which is the max for the 13-inch even though the
15-inch allows up to 32GiB. I think this should be at or near to the lowest
cost for the 15-inch model.