### PR TITLE
talent: update open source samples

### DIFF
--- a/talent/job-descriptions/engineering-section.md
+++ b/talent/job-descriptions/engineering-section.md
@@ -11,8 +11,8 @@ Engineering consists of five different teams that represent the architecture of 
 We care about Open Source. Everything we develop is available for anyone to read, modify, and contribute (under Apache 2.0 or GPL3 license). Some examples of our projects are:
 
 - [bblfsh/bblfshd](https://github.com/bblfsh/bblfshd): Babelfish server, turning code into Universal Abstract Syntax Trees (UASTs). 
-- [src-d/engine](https://github.com/src-d/engine): a library for running scalable data retrieval pipelines that process any number of Git repositories for source code analysis.  
 - [src-d/go-git](https://github.com/src-d/go-git): a highly extensible Git implementation in pure Go.
+- [src-d/go-mysql-server](https://github.com/src-d/go-mysql-server): a SQL engine written in Go, with a MySQL(ish) interface.
 - [src-d/ml](https://github.com/src-d/ml/tree/develop): a library to build and apply Machine Learning models on top of Universal Abstract Syntax Trees.
 
 If you are interested in understanding how we do code reviews, please take a look at the PRs on any of these projects. You can also learn more about our engineering methodology [here](https://github.com/src-d/guide/tree/master/engineering).


### PR DESCRIPTION
- The reference to engine was actually meant for jgit-spark-connector
(formerly known as engine).
- Added go-mysql-server.
