### PR TITLE
Go conventions: Use Go modules for applications

### DIFF
--- a/engineering/conventions/go.md
+++ b/engineering/conventions/go.md
@@ -7,7 +7,7 @@ This guide documents development conventions for Go at source{d}. Check [general
 
 ## Supported Go Versions
 
-* Our **libraries** support latest two stable major versions of Go (1.11.x and 1.12.x). Both versions should be included in Travis CI.
+* Our **libraries** support latest two stable major versions of Go (currently: 1.11.x and 1.12.x). Both versions should be included in Travis CI.
   * Some of our libraries may support more versions, specially when there is wide-adoption outside source{d}, (e.g. [go-git](https://github.com/src-d/go-git) which currently supports three.
 * Our **applications** support only latest [stable](https://golang.org/dl/#stable) Go version (1.12.x).
 

--- a/engineering/conventions/go.md
+++ b/engineering/conventions/go.md
@@ -7,17 +7,17 @@ This guide documents development conventions for Go at source{d}. Check [general
 
 ## Supported Go Versions
 
-* Our libraries support latest two stable major versions of Go (e.g. 1.10.x and 1.11.x). Both versions should be included in Travis CI.
+* Our **libraries** support latest two stable major versions of Go (1.11.x and 1.12.x). Both versions should be included in Travis CI.
   * Some of our libraries may support more versions, specially when there is wide-adoption outside source{d}, (e.g. [go-git](https://github.com/src-d/go-git) which currently supports three.
-* Our applications support only latest [stable](https://golang.org/dl/#stable) Go version.
+* Our **applications** support only latest [stable](https://golang.org/dl/#stable) Go version (1.12.x).
 
 ## Dependency Management
 
-* If your project is an application:
-  * Use [dep](https://github.com/golang/dep) to manage dependencies.
-  * Check in the `vendor` directory into git.
-* If your project is a library:
+* If your project is a **library**:
   * Use [gopkg.in](http://labix.org/gopkg.in) to provide versioned imports.
+* If your project is an **application**:
+  * Use [modules](https://github.com/golang/go/wiki/Modules) to manage dependencies.
+  * Check in the `vendor` directory into git (with `go mod vendor`).
 
 ## Build System
 


### PR DESCRIPTION
Update code convention to use Go modules for dependency management of applications. The change omits `vendor` intentionally. A separate discussion will be opened for this.

Also, highlight points for libraries/applications and update supported Go versions.

The reasoning is that we don't need an external tool like `dep` anymore to build applications. Our version policy for applications is to support one latest release of Go, which is 1.12, and it supports modules natively.

As noted in the [epic](https://github.com/src-d/backlog/issues/1392) (non-public link) most of our projects already switched to modules or are in the transition process. This change merely reflects the decision made previously and was already put into motion.