### PR TITLE
Go conventions: Use Go modules for libraries

### DIFF
--- a/engineering/conventions/go.md
+++ b/engineering/conventions/go.md
@@ -14,7 +14,9 @@ This guide documents development conventions for Go at source{d}. Check [general
 ## Dependency Management
 
 * If your project is a **library**:
-  * Use [gopkg.in](http://labix.org/gopkg.in) to provide versioned imports.
+  * Use [modules](https://github.com/golang/go/wiki/Modules) to manage dependencies and provide versioned imports.
+  * For libraries using `gopkg.in`, [migrate](https://github.com/golang/go/wiki/Modules#migrating-to-modules)
+    to Go modules by incrementing a major version and switching to Github imports. Make sure old `gopkg.in` import still works for previous versions.
 * If your project is an **application**:
   * Use [modules](https://github.com/golang/go/wiki/Modules) to manage dependencies.
   * Check in the `vendor` directory into git (with `go mod vendor`).


### PR DESCRIPTION
Update the code convention to use Go modules for dependency management of libraries.

The reasoning is that `gopkg.in` served only a single purpose - to provide a way to lock a major library version (thus an API version) in the import path. This concept is exactly the same as [semantic import versioning](https://github.com/golang/go/wiki/Modules#semantic-import-versioning) rule in Go modules.

The use of `gopkg.in` imports was a good solution for the time. Right now, however, Go modules are widely adopted by the community and supported by both Go 1.11 and 1.12. Our version policy for libraries is to support two latest release of Go, and both already support modules.

Thus, I think it doesn't make sense to use `gopkg.in` imports anymore. The number of project supporting modules is already massive and it will be even more true when 1.13 is released.

The best way to [migrate](https://github.com/golang/go/wiki/Modules#migrating-to-modules) our libraries is to increment the major version when adding modules support. This way old imports will be `gopkg.in/src-d/lib.v1` and new imports will be `github.com/src-d/lib/v2`.

Note that old library versions **must** continue to work after the change. We _don't want_ to break any of our users.

One may argue that this will require library clients to switch imports when updating to a new version. This is true, although the effect of this change is the same as any other major version bump. But instead of switching from `gopkg.in/src-d/lib.v1` to `gopkg.in/src-d/lib.v2` we will instead switch to `github.com/src-d/lib/v2`. This switch won't happen automatically and won't force anyone to update. Library users may update their imports at their own pace. 

As noted in the [epic](https://github.com/src-d/backlog/issues/1392) (non-public link) most of our projects already switched to modules or are in the transition process.