### PR TITLE
Go conventions: Don't push vendor to Git

### DIFF
--- a/engineering/conventions/go.md
+++ b/engineering/conventions/go.md
@@ -17,7 +17,7 @@ This guide documents development conventions for Go at source{d}. Check [general
   * Use [gopkg.in](http://labix.org/gopkg.in) to provide versioned imports.
 * If your project is an **application**:
   * Use [modules](https://github.com/golang/go/wiki/Modules) to manage dependencies.
-  * Check in the `vendor` directory into git (with `go mod vendor`).
+  * Do not check in the `vendor` directory into git.
 
 ## Build System
 


### PR DESCRIPTION
Update Go conventions to not check in `vendor` directory into Git.

The reasoning is that `vendor` was checked in for two purposes:
- Make the build repeatable.
- Make sure all dependencies are available even when upsteam is gone.

The first issue is solved by Go modules since it locks a specific Git tag/commit as well as computes the hash of the source code that is downloaded for a specific tag/commit. This ensures that builds are repeatable and remotes cannot change it by rewriting Git history.

The second issue is an edge case and is more related to archiving. There were a few rare cases when our dependencies disappeared from Github for different reasons. The post-modules way to solve this is to use a Go modules [proxy](https://github.com/golang/go/wiki/Modules#are-there-always-on-module-repositories-and-enterprise-proxies) like [Athens](https://github.com/gomods/athens).

Also, when Go 1.13 will be out [as was pointed out](https://github.com/src-d/backlog/issues/1392#issuecomment-483947269) the `vendor` won't be used by default anymore.

Having solutions for both problems in mind, I don't think it makes sense to check in the `vendor` into our repositories going forward.

Even in case the remote is gone, almost every developer will have a local copy of the dependency so we can create a "fork" repository under `src-d` to bring the dependency back online within minutes.

I would also argue that if we cannot rely on our own data retrieval projects to archive our own dependencies, we shouldn't be doing PGA in the first place. Let's make it work for the dependencies we vendor if we really want to archive them all.