### PR TITLE
update after Data Retrieval / Data Processing split

### DIFF
--- a/talent/engineering-teams-description.md
+++ b/talent/engineering-teams-description.md
@@ -10,10 +10,12 @@ This document describes the engineering teams at source{d} and how they interact
 
 ### Data Retrieval Team
 
-- The Data Retrieval team is developing source{d}'s high-level Engine for running scalable data retrieval pipelines that process and manipulate any number of code repositories for source code analysis. Written mostly in Scala, it aims to be robust, friendly and flexible: it is built on top of Apache Spark, accessible both via Scala and Python Spark APIs, and capable of running on large-scale distributed clusters over petabytes of data. This core tool will be used for building source{d}'s unique global scale open dataset of +60M code repositories for our Machine Learning research on source code.
+- The Data Retrieval Team builds tools to discover, fetch, store and access large collections of git repositories. Both for source{d} products, as well as in our internal cluster that aims to keep a full mirror of all public Git repositories.
 
-- Besides that, the team is developing GitBase, an SQL interface to Git repositories written in Go.
+### Data Processing Team
 
+- The Data Processing Team develops tools to analyze data with user-friendly APIs, mainly in SQL, but also Scala and Python.
+- Most of the code is written in Go and Scala. The later being used for our clustering layer based on Apache Spark.
 
 ### Language Analysis Team
 
@@ -28,6 +30,8 @@ This document describes the engineering teams at source{d} and how they interact
 - Besides that, the infrastructure team is also in charge of several other important services, such as databases, queues, CI, monitorization, logging, etc.
 
 ### Communication
+
+**NOTE: This section is not completely up to date with current team structure.**
 
 - The ```Applications``` team is responsible for building scalable developer tools on top of the research of the ```Machine Learning``` team and code analysis of the ```Language Analysis``` team. The ```Data Retrieval``` team retrieves and processes public source code in order to build the data pipelines for the Machine Learning team’s models with the support of ```Language Analysis```. Also, BabelFish from ```Language Analysis``` team is used in order to generate the datasets as Universal Abstract Syntax trees to be analyzed directly or given as input data to train the ML models. All the necessary services and computational clusters for every team, are supported by the ```Infrastructure team```.
 

--- a/talent/job-descriptions/engineering-section.md
+++ b/talent/job-descriptions/engineering-section.md
@@ -4,7 +4,8 @@ Engineering consists of five different teams that represent the architecture of 
 
 - Applications (Scala, Go, Python, and Frontend tools): Builds CLI/Web applications combining ML research with our stack.
 - Machine Learning (C++ and Python): Performs R&D for Machine Learning on Source Code.
-- Data Retrieval (Scala and Go): Builds the technology that finds, fetches, stores and analyzes over +60M Git repositories.
+- Data Retrieval (Go): Builds the technology that finds, fetches and stores over +60M Git repositories.
+- Data Processing (Scala and Go): Builds projects that enable data analysis for repositories and other data sources, mainly with SQL.
 - Language Analysis (Go and another +15): Focused on Babelfish, the universal code parsing server.
 - Infrastructure (Go and Python): Manages a cluser of on-prem bare metal servers with Kubernetes and CoreOS, and GCP for user facing applications. 
 


### PR DESCRIPTION
- Split DR/DP descriptions where they were pending.
- Marked section on communications between teams as outdated.
