### PR TITLE
Removing pronouns when referring to a manager role

### DIFF
--- a/engineering/repositories.md
+++ b/engineering/repositories.md
@@ -34,8 +34,8 @@ Each repository should belong to a team, and the full team has admin rights over
 * Non-maintainers at source{d} are not expected to do code review on PRs they are not asked to as a general practice.  However, they are allowed to at their discretion if they think it's appropriate on a specific case.
 * Desirable deadline for each code review is 1 working day.
 * If there is a disagreement among the PR author and multiple reviewers and consensus cannot be reached or [it's not worth to reach](http://bikeshed.org/) the maintainer has the final word.
-* A maintainer can merge his own PRs without code review, but it is encouraged to ask for a review  Merging without review, if done, should be reserved to fixing typos or minor maintenance tasks.
-* If a maintainer is missing, the Lead of the team that the project is owned by, or a backup maintainer designated by him will act as maintainer.
+* Maintainers can merge their own PRs without code review, but it is encouraged to ask for a review. Merging without review, if done, should be reserved to fixing typos or minor maintenance tasks.
+* If a maintainer is missing, a lead of the team that the project is owned by, or a backup maintainer designated by the lead will act as maintainer.
 
 ## Commit messages
 

--- a/general/expenses_travel.md
+++ b/general/expenses_travel.md
@@ -3,7 +3,7 @@
 We don't like to put strict rules in terms of what you can expense and what not, because we believe that you will treat the company's money in a responsible way. An easy way to achieve this is by following these principles:<br>
 * Spend source{d}'s money as if it was your own.
 * Research all available alternatives to make sure you're getting the best value for money.
-* Always ask your manager first before making a purchase. He might be able to point you to a better solution.
+* Always ask your manager first before making a purchase since there might be a better option available.
 * Once the decision has been made please request Esther to make the purchase, so that she can keep track of inventory as well as keep the receipt.
 * If you need any hardware for work, make sure to check our [Hardware list](https://github.com/src-d/guide/blob/master/general/available_hardware.md) and ask Esther to buy anything you need.
 * If you see yourself in the situation of needing to pay something out of your own pocket please make sure that you keep all the receipts and hand them over to Esther for her to do the reimbursement. You should fill in the [expenses sheet](https://docs.google.com/a/sourced.tech/spreadsheets/d/1efa5uU1b95FzxhqRPcUOF1UOiAa1j0i08ae15y22J6c/edit?usp=sharing) with the amount in EUR to be sure that the reimbursment is done properly. If it's a physical item, make sure to give it to her when you receive it for her to update the inventory. 


### PR DESCRIPTION
Noticed that only 'he' is used when referring to a manager role. To make it more inclusive, re-wrote a sentence a little bit.