### PR TITLE
Correct marking for proper interactive rebasing

### DIFF
--- a/developer-community/fix-DCO.md
+++ b/developer-community/fix-DCO.md
@@ -59,7 +59,7 @@ Write `^` as many times as there are commits in your pull request.
 A text will open; ensure that there are only your recent commits listed there.
 Otherwise, exit the file and repeat the rebase command with the correct number of `^`.
 
-Now, mark all the commits with "reword" or "r". The rebase process will stop at each of your commits.
+Now, mark all the commits with "edit" or "e". The rebase process will stop at each of your commits.
 
 Execute as many times as you are asked to:
 


### PR DESCRIPTION
Rewording doesn't allow the --amend flag so you can't add the signoff flag.  You need to do `edit` or `e`.